### PR TITLE
Add sorting

### DIFF
--- a/src/components/TheMangaList.vue
+++ b/src/components/TheMangaList.vue
@@ -52,7 +52,7 @@
 </script>
 
 <style lang="scss" scoped>
-  // .el-link /deep/ .el-link--inner {
-  //   word-wrap: normal;
-  // }
+  .series-title {
+    word-break: normal;
+  }
 </style>

--- a/src/components/TheMangaList.vue
+++ b/src/components/TheMangaList.vue
@@ -1,14 +1,17 @@
 <template lang="pug">
-  el-table(:data="tableData")
-    el-table-column(prop="series" label="Name")
+  el-table(
+    :data="tableData"
+    :default-sort = "{ prop: 'series.title', order: 'descending' }"
+  )
+    el-table-column(prop="series.title" label="Name" sortable)
       template(slot-scope="scope")
-        el-link(
+        el-link.series-title(
           :href="scope.row.series.url"
           :underline="false"
           target="_blank"
         )
           | {{ scope.row.series.title }}
-    el-table-column(prop="latestChapter" label="Latest Chapter")
+    el-table-column(prop="latestChapter.url" label="Latest Chapter")
       template(slot-scope="scope")
         el-link(
           :href="scope.row.latestChapter.url"
@@ -16,7 +19,7 @@
           target="_blank"
         )
           | {{ scope.row.latestChapter.info.chapter }}
-    el-table-column(prop="latestChapterReleasedAt" label="Released")
+    el-table-column(prop="latestChapter.info.timestamp" label="Released" sortable)
       template(slot-scope="scope")
         | {{ releasedAt(scope.row.latestChapter.info.timestamp) }}
 </template>

--- a/tests/components/__snapshots__/TheMangaList.spec.js.snap
+++ b/tests/components/__snapshots__/TheMangaList.spec.js.snap
@@ -4,7 +4,7 @@ exports[`TheMangaList.vue :props :tableData - renders rows 1`] = `
 <tbody>
   <tr class="el-table__row">
     <td rowspan="1" colspan="1" class="el-table_1_column_1  ">
-      <div class="cell"><a href="series.example.url" target="_blank" class="el-link el-link--default">
+      <div class="cell"><a href="series.example.url" target="_blank" class="series-title el-link el-link--default">
           <!----><span class="el-link--inner">Manga Title</span>
           <!----></a></div>
     </td>


### PR DESCRIPTION
I forgot to add this in #8, but this PR adds the ability to sort by release date and title, with the default being set to the title.

I also add word-break on the title, as otherwise, long manga titles don't look too good, especially on mobile