### PR TITLE
Add Trackr.moe MangaDex importer

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "core-js": "^2.6.5",
     "dayjs": "^1.8.15",
     "element-ui": "^2.4.5",
+    "p-limit": "^2.2.0",
     "pug-plain-loader": "^1.0.0",
     "vue": "^2.6.10",
     "vue-analytics": "^5.17.0",

--- a/src/components/ProgressBar.vue
+++ b/src/components/ProgressBar.vue
@@ -1,0 +1,30 @@
+<template lang="pug">
+  el-progress(:percentage="percentage" :color="colors")
+</template>
+
+<script>
+  import { Progress } from 'element-ui';
+
+  export default {
+    components: {
+      'el-progress': Progress,
+    },
+    props: {
+      percentage: {
+        type: Number,
+        default: 0,
+      },
+    },
+    data() {
+      return {
+        colors: [
+          { color: '#f56c6c', percentage: 20 },
+          { color: '#e6a23c', percentage: 40 },
+          { color: '#1989fa', percentage: 60 },
+          { color: '#6f7ad3', percentage: 80 },
+          { color: '#5cb87a', percentage: 100 },
+        ],
+      };
+    },
+  };
+</script>

--- a/src/components/TheMangaList.vue
+++ b/src/components/TheMangaList.vue
@@ -12,15 +12,19 @@
         )
           | {{ scope.row.series.title }}
     el-table-column(prop="latestChapter.url" label="Latest Chapter")
-      template(slot-scope="scope")
+      template(v-if='scope.row.latestChapter.info' slot-scope="scope")
         el-link(
           :href="scope.row.latestChapter.url"
           :underline="false"
           target="_blank"
         )
           | {{ scope.row.latestChapter.info.chapter }}
-    el-table-column(prop="latestChapter.info.timestamp" label="Released" sortable)
-      template(slot-scope="scope")
+    el-table-column(
+      prop="latestChapter.info.timestamp"
+      label="Released"
+      sortable
+    )
+      template(v-if='scope.row.latestChapter.info' slot-scope="scope")
         | {{ releasedAt(scope.row.latestChapter.info.timestamp) }}
 </template>
 

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -1,5 +1,15 @@
 import axios from 'axios';
 
+const sanitizeManga = (manga) => {
+  const newManga = {};
+  const { title, url, latestChapter } = manga;
+
+  newManga.series = { title, url };
+  newManga.latestChapter = latestChapter;
+
+  return newManga;
+};
+
 // This can extract both the series and chapter, we want to make use of that
 export const extractSeriesID = url => url.match(/(?<=\/)\d+/g);
 
@@ -8,13 +18,15 @@ export const getManga = id => axios
   .then((response) => {
     if (response.data.error) { return {}; }
 
-    const newManga = {};
-    const { title, url, latestChapter } = response.data;
-
-    newManga.series = { title, url };
-    newManga.latestChapter = latestChapter;
-
-    return newManga;
+    return sanitizeManga(response.data);
   });
 
-export const getAllManga = () => {};
+export const getMangaBulk = ids => axios
+  .post('https://api.kenmei.co/api/v1/series/bulk', { ids })
+  .then((response) => {
+    if (response.data.error) { return []; }
+
+    return Object
+      .values(response.data.successful)
+      .map(manga => sanitizeManga(manga));
+  });

--- a/src/services/importer.js
+++ b/src/services/importer.js
@@ -1,0 +1,13 @@
+import { extractSeriesID } from '@/services/api';
+
+export default (list) => {
+  const mangaDexSeries = list.series.reading.manga.filter(
+    series => series.site_data.site === 'mangadex.org'
+  );
+
+  const mangaDexIDs = mangaDexSeries.map(
+    manga => extractSeriesID(manga.full_title_url)
+  );
+
+  return [].concat(...mangaDexIDs);
+};

--- a/src/stylesheets/global.scss
+++ b/src/stylesheets/global.scss
@@ -15,5 +15,6 @@ body {
   );
   margin: 0;
   height: 100%;
+  overflow-y: auto;
   font-family: "Helvetica Neue",Helvetica,"PingFang SC","Hiragino Sans GB","Microsoft YaHei","微软雅黑",Arial,sans-serif;
 }

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -1,7 +1,6 @@
 <template lang="pug">
-  #home
-    .container.mx-auto.w-full.h-full.flex.flex-col.justify-center.items-center
-      router-view
+  #home.h-full
+    router-view
 </template>
 
 <script>
@@ -9,9 +8,3 @@
     name: 'Home',
   };
 </script>
-
-<style lang="scss" scoped>
-  #home {
-    height: 100%;
-  }
-</style>

--- a/src/views/LandingPage.vue
+++ b/src/views/LandingPage.vue
@@ -1,43 +1,44 @@
 <template lang="pug">
-  el-card.text-center.max-w-lg.mx-5(shadow="always" class="md:mx-0")
-    img.max-w-xs.w-full.inline.logo(src='@/assets/logo_transparent.png')
-    .welcome-text.font-size-b.font-line-height-secondary
-      p
-        | Welcome to Kenmei, a new manga tracking website currently in
-        | development.
-      p
-        | Inspired by
-        |
-        el-link.inline.align-baseline(
-          href="https://www.trackr.moe" :underline="false"
+  .container.mx-auto.w-full.h-full.flex.flex-col.justify-center.items-center
+    el-card.text-center.max-w-lg.mx-5.justify-center(shadow="always" class="md:mx-0")
+      img.max-w-xs.w-full.inline.logo(src='@/assets/logo_transparent.png')
+      .welcome-text.font-size-b.font-line-height-secondary
+        p
+          | Welcome to Kenmei, a new manga tracking website currently in
+          | development.
+        p
+          | Inspired by
+          |
+          el-link.inline.align-baseline(
+            href="https://www.trackr.moe" :underline="false"
+          )
+            | trackr.moe
+          |, the best manga tracking website,
+          |
+          el-link.inline.align-baseline(
+            href="https://blog.codeanimu.net/posts/2019/07/trackr-moe-the-future/"
+            :underline="false"
+          )
+            | that is now slated to be closed
+          |, Kenmei is here to replace it
+          | and provide even more features, for all manga fans out there!
+        p
+          | If you would like to get notified, when registrations open, please
+          | leave your email below.
+      .email-form
+        form(
+          action='https://tinyletter.com/kenmei'
+          method='post'
+          target='popupwindow'
+          onsubmit="window.open('https://tinyletter.com/kenmei', 'popupwindow', 'scrollbars=yes,width=800,height=600');"
         )
-          | trackr.moe
-        |, the best manga tracking website,
-        |
-        el-link.inline.align-baseline(
-          href="https://blog.codeanimu.net/posts/2019/07/trackr-moe-the-future/"
-          :underline="false"
-        )
-          | that is now slated to be closed
-        |, Kenmei is here to replace it
-        | and provide even more features, for all manga fans out there!
-      p
-        | If you would like to get notified, when registrations open, please
-        | leave your email below.
-    .email-form
-      form(
-        action='https://tinyletter.com/kenmei'
-        method='post'
-        target='popupwindow'
-        onsubmit="window.open('https://tinyletter.com/kenmei', 'popupwindow', 'scrollbars=yes,width=800,height=600');"
-      )
-        el-input.my-5(
-          v-model="form.email"
-          placeholder="Please enter your email"
-          name='email'
-        )
-        input(type='hidden', value='1', name='embed')
-        input.el-button(type='submit', value='Subscribe')
+          el-input.my-5(
+            v-model="form.email"
+            placeholder="Please enter your email"
+            name='email'
+          )
+          input(type='hidden', value='1', name='embed')
+          input.el-button(type='submit', value='Subscribe')
 </template>
 
 <script>

--- a/src/views/MangaList.vue
+++ b/src/views/MangaList.vue
@@ -58,7 +58,7 @@
       mangaDexSearch() {
         const mangaID = extractSeriesID(this.mangaURL);
 
-        if (this.tableData.some(manga => manga.series.url.includes(mangaID))) {
+        if (this.alreadyExists(mangaID)) {
           Message.info('Manga already added');
           this.dialogVisible = false;
           return;
@@ -89,6 +89,9 @@
         this.dialogVisible = false;
         loading.close();
         this.mangaURL = '';
+      },
+      alreadyExists(mangaID) {
+        return this.tableData.some(manga => manga.series.url.includes(mangaID));
       },
     },
   };

--- a/src/views/MangaList.vue
+++ b/src/views/MangaList.vue
@@ -8,8 +8,36 @@
         round
       )
         | Add Manga
+      el-button.float-right.mr-3(
+        type="success"
+        size="medium"
+        @click="importDialogVisible = true"
+        round
+      )
+        i.el-icon-upload2.mr-1
+        | Import
     .row.mx-5(class="md:mx-0")
       the-manga-list(:tableData='tableData')
+    el-dialog(
+      title="Import Manga List"
+      :visible.sync="importDialogVisible"
+      custom-class="custom-dialog"
+      width="400px"
+    )
+      el-upload(
+        ref="upload"
+        action=""
+        :http-request="processUpload"
+        :multiple="false"
+        :show-file-list="false"
+        accept="application/json"
+        drag
+        )
+        i.el-icon-upload
+        .el-upload__text
+          | Drop file here or click to upload
+        .el-upload__tip(slot="tip")
+          | You can download your Trackr.moe list here
     el-dialog(
       title="Add Manga"
       :visible.sync="dialogVisible"
@@ -33,7 +61,7 @@
 
 <script>
   import {
-    Message, Loading, Dialog, Button, Input,
+    Message, Loading, Dialog, Button, Input, Upload,
   } from 'element-ui';
 
   import TheMangaList from '@/components/TheMangaList';
@@ -46,12 +74,14 @@
       'el-button': Button,
       'el-dialog': Dialog,
       'el-input': Input,
+      'el-upload': Upload,
     },
     data() {
       return {
         tableData: [],
         mangaURL: '',
         dialogVisible: false,
+        importDialogVisible: false,
       };
     },
     methods: {

--- a/src/views/MangaList.vue
+++ b/src/views/MangaList.vue
@@ -4,9 +4,11 @@
       el-button.float-right(
         ref="openAddMangaModalButton"
         type="primary"
+        size="medium"
         @click="dialogVisible = true"
         round
       )
+        i.el-icon-plus.mr-1
         | Add Manga
       el-button.float-right.mr-3(
         type="success"

--- a/src/views/MangaList.vue
+++ b/src/views/MangaList.vue
@@ -95,6 +95,10 @@
 </script>
 
 <style media="screen" lang="scss">
+  .el-button.float-right + .el-button.float-right {
+    @apply ml-0;
+  }
+
   @media (max-width: 640px) {
     .custom-dialog {
       width: 100% !important;

--- a/src/views/MangaList.vue
+++ b/src/views/MangaList.vue
@@ -1,65 +1,66 @@
 <template lang="pug">
-  .flex.flex-col.w-full.max-w-4xl
-    .row.mx-5.mb-5(class="md:mx-0")
-      el-button.float-right(
-        ref="openAddMangaModalButton"
-        type="primary"
-        size="medium"
-        @click="dialogVisible = true"
-        round
-      )
-        i.el-icon-plus.mr-1
-        | Add Manga
-      el-button.float-right.mr-3(
-        type="success"
-        size="medium"
-        @click="importDialogVisible = true"
-        round
-      )
-        i.el-icon-upload2.mr-1
-        | Import
-    .row.mx-5(class="md:mx-0")
-      the-manga-list(:tableData='tableData')
-    el-dialog(
-      title="Import Manga List"
-      :visible.sync="importDialogVisible"
-      custom-class="custom-dialog"
-      width="400px"
-    )
-      el-upload(
-        ref="upload"
-        action=""
-        :http-request="processUpload"
-        :multiple="false"
-        :show-file-list="false"
-        accept="application/json"
-        drag
-        )
-        i.el-icon-upload
-        .el-upload__text
-          | Drop file here or click to upload
-        .el-upload__tip(slot="tip")
-          | You can download your Trackr.moe list here
-    el-dialog(
-      title="Add Manga"
-      :visible.sync="dialogVisible"
-      custom-class="custom-dialog"
-      width="400px"
-    )
-      label.font-size-b.primary-text MangaDex series URL
-      el-input.mt-3(
-        v-model="mangaURL"
-        placeholder="https://mangadex.org/title/7139/one-punch-man"
-      )
-      span(slot="footer" class="dialog-footer")
-        el-button(@click="dialogVisible = false") Cancel
-        el-button(
-          ref="addMangaButton"
+  .container.mx-auto.w-full.h-full.flex.flex-col.items-center
+    .flex.flex-col.w-full.max-w-4xl.py-16
+      .mx-5.mb-5(class="md:mx-0")
+        el-button.float-right(
+          ref="openAddMangaModalButton"
           type="primary"
-          @click="mangaDexSearch"
-          :disabled="mangaURL.length === 0"
+          size="medium"
+          @click="dialogVisible = true"
+          round
         )
-          | Add
+          i.el-icon-plus.mr-1
+          | Add Manga
+        el-button.float-right.mr-3(
+          type="success"
+          size="medium"
+          @click="importDialogVisible = true"
+          round
+        )
+          i.el-icon-upload2.mr-1
+          | Import
+      .flex-grow.mx-5(class="md:mx-0")
+        the-manga-list(:tableData='tableData')
+      el-dialog(
+        title="Import Manga List"
+        :visible.sync="importDialogVisible"
+        custom-class="custom-dialog"
+        width="400px"
+      )
+        el-upload(
+          ref="upload"
+          action=""
+          :http-request="processUpload"
+          :multiple="false"
+          :show-file-list="false"
+          accept="application/json"
+          drag
+          )
+          i.el-icon-upload
+          .el-upload__text
+            | Drop file here or click to upload
+          .el-upload__tip(slot="tip")
+            | You can download your Trackr.moe list here
+      el-dialog(
+        title="Add Manga"
+        :visible.sync="dialogVisible"
+        custom-class="custom-dialog"
+        width="400px"
+      )
+        label.font-size-b.primary-text MangaDex series URL
+        el-input.mt-3(
+          v-model="mangaURL"
+          placeholder="https://mangadex.org/title/7139/one-punch-man"
+        )
+        span(slot="footer" class="dialog-footer")
+          el-button(@click="dialogVisible = false") Cancel
+          el-button(
+            ref="addMangaButton"
+            type="primary"
+            @click="mangaDexSearch"
+            :disabled="mangaURL.length === 0"
+          )
+            | Add
 </template>
 
 <script>

--- a/src/views/MangaList.vue
+++ b/src/views/MangaList.vue
@@ -42,6 +42,7 @@
       title="Add Manga"
       :visible.sync="dialogVisible"
       custom-class="custom-dialog"
+      width="400px"
     )
       label.font-size-b.primary-text MangaDex series URL
       el-input.mt-3(

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,4 +1,5 @@
 module.exports = {
+  important: true,
   theme: {
     extend: {},
   },

--- a/tests/components/ProgressBar.spec.js
+++ b/tests/components/ProgressBar.spec.js
@@ -1,0 +1,10 @@
+import { shallowMount } from '@vue/test-utils';
+import ProgressBar from '@/components/ProgressBar.vue';
+
+describe('ProgressBar.vue', () => {
+  it('renders progress bar', () => {
+    const mangaList = shallowMount(ProgressBar);
+
+    expect(mangaList.html()).toMatchSnapshot();
+  });
+});

--- a/tests/components/__snapshots__/ProgressBar.spec.js.snap
+++ b/tests/components/__snapshots__/ProgressBar.spec.js.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ProgressBar.vue renders progress bar 1`] = `<el-progress-stub type="line" percentage="0" strokewidth="6" width="126" showtext="true" color="[object Object],[object Object],[object Object],[object Object],[object Object]"></el-progress-stub>`;

--- a/tests/services/api.spec.js
+++ b/tests/services/api.spec.js
@@ -54,4 +54,54 @@ describe('API', () => {
       });
     });
   });
+
+  describe('getMangaBulk()', () => {
+    it('makes a request to the API bulk endpoint and delegate to sanitizeManga', () => {
+      const mockData = {
+        successful: {
+          1: {
+            title: 'Manga Title',
+            url: 'series.example.url',
+            latestChapter: {
+              url: 'chapter.example.url',
+              info: {
+                chapter: '10',
+                title: 'Chapter Title',
+                timestamp: 1522299049,
+              },
+            },
+          },
+          2: {
+            title: 'Manga Title',
+            url: 'series.example.url',
+            latestChapter: {
+              url: 'chapter.example.url',
+              info: {
+                chapter: '10',
+                title: 'Chapter Title',
+                timestamp: 1522299049,
+              },
+            },
+          },
+        },
+        failed: ['3'],
+      };
+
+      axios.post.mockResolvedValue({ status: 200, data: mockData });
+
+      apiService.getMangaBulk('1 2 3').then((data) => {
+        expect(data.length).toBe(2);
+      });
+    });
+
+    it('makes a request to the API and returns empty object if not found', () => {
+      axios.post.mockResolvedValue({
+        status: 200, data: { error: 'not_found' },
+      });
+
+      apiService.getMangaBulk('1 2 3').then((data) => {
+        expect(data).toEqual([]);
+      });
+    });
+  });
 });

--- a/tests/services/importer.spec.js
+++ b/tests/services/importer.spec.js
@@ -1,0 +1,25 @@
+import Importer from '@/services/importer';
+
+describe('Importer', () => {
+  it('filters list to return MangaDex IDs', () => {
+    const list = {
+      series: {
+        reading: {
+          manga: [{
+            full_title_url: 'https://mangadex.org/manga/24121',
+            site_data: {
+              site: 'mangadex.org',
+            },
+          }, {
+            full_title_url: 'https://mangarock.example.test',
+            site_data: {
+              site: 'mangarock.org',
+            },
+          }],
+        },
+      },
+    };
+
+    expect(Importer(list)).toEqual(['24121']);
+  });
+});

--- a/tests/views/__snapshots__/LandingPage.spec.js.snap
+++ b/tests/views/__snapshots__/LandingPage.spec.js.snap
@@ -1,77 +1,81 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`LandingPage.vue renders the page 1`] = `
-<el-card-stub
-  class="text-center max-w-lg mx-5 md:mx-0"
-  shadow="always"
+<div
+  class="container mx-auto w-full h-full flex flex-col justify-center items-center"
 >
-  <img
-    class="max-w-xs w-full inline logo"
-    src="@/assets/logo_transparent.png"
-  />
-  <div
-    class="welcome-text font-size-b font-line-height-secondary"
+  <el-card-stub
+    class="text-center max-w-lg mx-5 justify-center md:mx-0"
+    shadow="always"
   >
-    <p>
-      Welcome to Kenmei, a new manga tracking website currently in
-development.
-    </p>
-    <p>
-      Inspired by
-
-      <el-link-stub
-        class="inline align-baseline"
-        href="https://www.trackr.moe"
-        type="default"
-      >
-        trackr.moe
-      </el-link-stub>
-      , the best manga tracking website,
-
-      <el-link-stub
-        class="inline align-baseline"
-        href="https://blog.codeanimu.net/posts/2019/07/trackr-moe-the-future/"
-        type="default"
-      >
-        that is now slated to be closed
-      </el-link-stub>
-      , Kenmei is here to replace it
-and provide even more features, for all manga fans out there!
-    </p>
-    <p>
-      If you would like to get notified, when registrations open, please
-leave your email below.
-    </p>
-  </div>
-  <div
-    class="email-form"
-  >
-    <form
-      action="https://tinyletter.com/kenmei"
-      method="post"
-      onsubmit="window.open('https://tinyletter.com/kenmei', 'popupwindow', 'scrollbars=yes,width=800,height=600');"
-      target="popupwindow"
+    <img
+      class="max-w-xs w-full inline logo"
+      src="@/assets/logo_transparent.png"
+    />
+    <div
+      class="welcome-text font-size-b font-line-height-secondary"
     >
-      <el-input-stub
-        autocomplete="off"
-        class="my-5"
-        name="email"
-        placeholder="Please enter your email"
-        type="text"
-        validateevent="true"
-        value=""
-      />
-      <input
-        name="embed"
-        type="hidden"
-        value="1"
-      />
-      <input
-        class="el-button"
-        type="submit"
-        value="Subscribe"
-      />
-    </form>
-  </div>
-</el-card-stub>
+      <p>
+        Welcome to Kenmei, a new manga tracking website currently in
+development.
+      </p>
+      <p>
+        Inspired by
+
+        <el-link-stub
+          class="inline align-baseline"
+          href="https://www.trackr.moe"
+          type="default"
+        >
+          trackr.moe
+        </el-link-stub>
+        , the best manga tracking website,
+
+        <el-link-stub
+          class="inline align-baseline"
+          href="https://blog.codeanimu.net/posts/2019/07/trackr-moe-the-future/"
+          type="default"
+        >
+          that is now slated to be closed
+        </el-link-stub>
+        , Kenmei is here to replace it
+and provide even more features, for all manga fans out there!
+      </p>
+      <p>
+        If you would like to get notified, when registrations open, please
+leave your email below.
+      </p>
+    </div>
+    <div
+      class="email-form"
+    >
+      <form
+        action="https://tinyletter.com/kenmei"
+        method="post"
+        onsubmit="window.open('https://tinyletter.com/kenmei', 'popupwindow', 'scrollbars=yes,width=800,height=600');"
+        target="popupwindow"
+      >
+        <el-input-stub
+          autocomplete="off"
+          class="my-5"
+          name="email"
+          placeholder="Please enter your email"
+          type="text"
+          validateevent="true"
+          value=""
+        />
+        <input
+          name="embed"
+          type="hidden"
+          value="1"
+        />
+        <input
+          class="el-button"
+          type="submit"
+          value="Subscribe"
+        />
+      </form>
+    </div>
+  </el-card-stub>
+</div>
 `;

--- a/yarn.lock
+++ b/yarn.lock
@@ -7352,7 +7352,7 @@ p-limit@^1.0.0, p-limit@^1.1.0:
   dependencies:
     p-try "^1.0.0"
 
-p-limit@^2.0.0:
+p-limit@^2.0.0, p-limit@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-2.2.0.tgz#417c9941e6027a9abcba5092dd2904e255b5fbc2"
   integrity sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==


### PR DESCRIPTION
This PR adds the ability to import Trackr.moe JSON manga list. Currently, it only allows importing currently MangaDex series from `Reading` folder. 

Due to timeout issues that occur with very large imports, this version will only allow importing of the first 20 series. When user sessions are a thing, I'll be able to delegate this work to a background worker

## Preview
![dexSmall](https://user-images.githubusercontent.com/4270980/62835144-ececf780-bc4c-11e9-987b-4571bf78d563.gif)

## To-do
1. Add manual mocks for ElementUI, so that currently skipped tests can be run again.
2. Refactor tests to avoid calling individual methods (as they should act as private) and instead test them as part of the Importing functionality