### PR TITLE
Update regex to not use negative lookbehind

### DIFF
--- a/src/services/api.js
+++ b/src/services/api.js
@@ -11,7 +11,7 @@ const sanitizeManga = (manga) => {
 };
 
 // This can extract both the series and chapter, we want to make use of that
-export const extractSeriesID = url => url.match(/(?<=\/)\d+/g);
+export const extractSeriesID = url => url.match(/(?!\/)\d+/g);
 
 export const getManga = id => axios
   .get(`https://api.kenmei.co/api/v1/series/${id}`)


### PR DESCRIPTION
It's not supported on Firefox and Safari, so we need to use a different regex.