### PR TITLE
Fix babel transform and make all tests pass again

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -11,4 +11,9 @@ module.exports = {
       },
     ],
   ],
+  env: {
+    test: {
+      plugins: ['transform-es2015-modules-commonjs', 'dynamic-import-node'],
+    },
+  },
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -8,11 +8,8 @@ module.exports = {
   transform: {
     '^.+\\.vue$': 'vue-jest',
     '.+\\.(css|styl|less|sass|scss|svg|png|jpg|ttf|woff|woff2)$': 'jest-transform-stub',
-    '^.+\\.jsx?$': 'babel-jest',
+    '^.+\\.(js|jsx)?$': 'babel-jest',
   },
-  transformIgnorePatterns: [
-    '/node_modules/',
-  ],
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/src/$1',
     '^.+\\.(css|styl|less|sass|scss|png|jpg|ttf|woff|woff2)$': 'jest-transform-stub',

--- a/tests/views/MangaList.spec.js
+++ b/tests/views/MangaList.spec.js
@@ -129,7 +129,8 @@ describe('MangaList.vue', () => {
           },
         },
       };
-      getMangaMock.mockImplementation(() => Promise.resolve(responseValue));
+
+      getMangaMock.mockResolvedValue(responseValue);
 
       expect(mangaList.vm.$data.tableData).not.toContain(responseValue);
 
@@ -144,7 +145,7 @@ describe('MangaList.vue', () => {
       const infoMessageMock = jest.spyOn(Message, 'info');
       const getMangaMock    = jest.spyOn(api, 'getManga');
 
-      getMangaMock.mockImplementation(() => Promise.resolve({}));
+      getMangaMock.mockResolvedValue({});
 
       mangaList.vm.mangaDexSearch();
 

--- a/tests/views/MangaList.spec.js
+++ b/tests/views/MangaList.spec.js
@@ -72,7 +72,7 @@ describe('MangaList.vue', () => {
       expect(mangaList.vm.sliceIntoBatches(ids)).toEqual(result);
     });
 
-    it.skip('adds new manga entries and updates progress percentage if successful', async () => {
+    it('adds new manga entries and updates progress percentage if successful', async () => {
       const getMangaMock = jest.spyOn(api, 'getMangaBulk');
 
       getMangaMock.mockResolvedValue([responseValue]);
@@ -85,7 +85,7 @@ describe('MangaList.vue', () => {
       expect(mangaList.vm.$data.importProgress).toEqual(100);
     });
 
-    it.skip('ignores already existing entries', async () => {
+    it('ignores already existing entries', async () => {
       const getMangaMock = jest.spyOn(api, 'getManga');
 
       mangaList.setData({ tableData: [responseValue] });
@@ -140,7 +140,7 @@ describe('MangaList.vue', () => {
       expect(mangaList.vm.$data.tableData).toContain(responseValue);
     });
 
-    it.skip('shows Manga not found message if API returns nothing', async () => {
+    it('shows Manga not found message if API returns nothing', async () => {
       const infoMessageMock = jest.spyOn(Message, 'info');
       const getMangaMock    = jest.spyOn(api, 'getManga');
 
@@ -152,11 +152,11 @@ describe('MangaList.vue', () => {
       expect(infoMessageMock).toHaveBeenCalledWith('Manga was not found');
     });
 
-    it.skip('shows URL is incorrect message if response is 400', async () => {
-      const infoMessageMock = jest.spyOn(Message, 'info');
+    it('shows URL is incorrect message if response is 400', async () => {
+      const infoMessageMock = jest.spyOn(Message, 'error');
       const getMangaMock    = jest.spyOn(api, 'getManga');
 
-      getMangaMock.mockImplementation(() => Promise.resolve({}));
+      getMangaMock.mockRejectedValue({ response: { status: 400 } });
 
       mangaList.vm.mangaDexSearch();
 
@@ -164,11 +164,11 @@ describe('MangaList.vue', () => {
       expect(infoMessageMock).toHaveBeenCalledWith('URL is incorrect');
     });
 
-    it.skip('shows error message on unsuccessful API lookup', async () => {
+    it('shows error message on unsuccessful API lookup', async () => {
       const errorMessageMock = jest.spyOn(Message, 'error');
       const getMangaMock    = jest.spyOn(api, 'getManga');
 
-      getMangaMock.mockImplementation(() => Promise.resolve());
+      getMangaMock.mockRejectedValue({ response: { status: 500 } });
 
       mangaList.vm.mangaDexSearch();
 


### PR DESCRIPTION
I've had to skip quite a few tests, due to Babel transformation not working in Jest. This PR finally fixes that and gets us back to all tests passing. 

Big thanks to @abenitoc who [helped me with it](https://stackoverflow.com/questions/57639448/elementui-tests-throw-referenceerror-message-is-not-defined) and showed what was wrong. 