### PR TITLE
Add ability to multiselect and delete series

### DIFF
--- a/src/components/TheMangaList.vue
+++ b/src/components/TheMangaList.vue
@@ -2,7 +2,9 @@
   el-table.shadow-lg.rounded(
     :data="tableData"
     :default-sort = "{ prop: 'series.title', order: 'descending' }"
+    @selection-change="handleSelectionChange"
   )
+    el-table-column(type="selection")
     el-table-column(prop="series.title" label="Name" sortable)
       template(slot-scope="scope")
         el-link.break-normal(
@@ -56,6 +58,9 @@
     methods: {
       releasedAt(timestamp) {
         return dayjs().to(dayjs.unix(timestamp));
+      },
+      handleSelectionChange(val) {
+        this.$emit('seriesSelected', val);
       },
     },
   };

--- a/src/views/MangaList.vue
+++ b/src/views/MangaList.vue
@@ -2,6 +2,16 @@
   .container.mx-auto.w-full.h-full.flex.flex-col.items-center
     .flex.flex-col.w-full.max-w-4xl.pt-32.pb-16
       .mx-5.mb-5(class="md:mx-0")
+        el-button(
+          v-show="selectedSeries.length > 0"
+          ref="removeSeriesButton"
+          type="danger"
+          size="medium"
+          @click="removeSeries"
+          round
+        )
+          i.el-icon-delete.mr-1
+          | Remove
         el-button.float-right(
           ref="openAddMangaModalButton"
           type="primary"
@@ -20,7 +30,7 @@
           i.el-icon-upload2.mr-1
           | Import
       .flex-grow.mx-5(class="md:mx-0")
-        the-manga-list(:tableData='tableData')
+        the-manga-list(:tableData='tableData' @seriesSelected="handleSelection")
       el-dialog(
         title="Import Manga List"
         :visible.sync="importDialogVisible"
@@ -96,13 +106,32 @@
     data() {
       return {
         tableData: [],
+        selectedSeries: [],
         mangaURL: '',
         dialogVisible: false,
         importDialogVisible: false,
         importProgress: 0,
       };
     },
+    computed: {
+      // TODO: Lookup by DB id instead of title when we'll start storing
+      // series on back-end
+      selectedSeriesTitles() {
+        return this.selectedSeries.map(series => series.series.title);
+      },
+    },
     methods: {
+      handleSelection(selectedSeries) {
+        this.selectedSeries = selectedSeries;
+      },
+      // TODO: When we are going to store these on the back-end, make a
+      // relevant API call
+      removeSeries() {
+        // console.log(this.selectedSeriesTitles);
+        this.tableData = this.tableData.filter(
+          item => !this.selectedSeriesTitles.includes(item.series.title)
+        );
+      },
       mangaDexSearch() {
         const mangaID = extractSeriesID(this.mangaURL);
 

--- a/tests/components/TheMangaList.spec.js
+++ b/tests/components/TheMangaList.spec.js
@@ -4,33 +4,43 @@ import flushPromises from 'flush-promises';
 import MangaList from '@/components/TheMangaList.vue';
 
 describe('TheMangaList.vue', () => {
-  describe(':props', () => {
-    let mangaList;
+  let mangaList;
 
-    beforeEach(() => {
-      mangaList = mount(MangaList, {
-        sync: false,
-        propsData: {
-          tableData: [
-            {
-              series: {
-                title: 'Manga Title',
-                url: 'series.example.url',
-              },
-              latestChapter: {
-                url: 'chapter.example.url',
-                info: {
-                  chapter: '10',
-                  title: 'Chapter Title',
-                  timestamp: 1522299049,
-                },
+  beforeEach(() => {
+    mangaList = mount(MangaList, {
+      sync: false,
+      propsData: {
+        tableData: [
+          {
+            series: {
+              title: 'Manga Title',
+              url: 'series.example.url',
+            },
+            latestChapter: {
+              url: 'chapter.example.url',
+              info: {
+                chapter: '10',
+                title: 'Chapter Title',
+                timestamp: 1522299049,
               },
             },
-          ],
-        },
-      });
+          },
+        ],
+      },
     });
+  });
 
+  describe('@events', () => {
+    it.skip('@handleSelectionChange - when selecting rows, emits seriesSelected', async () => {
+      await flushPromises();
+
+      mangaList.find('.el-checkbox').trigger('click');
+
+      expect(mangaList.emitted('seriesSelected')).toBeTruthy();
+    });
+  });
+
+  describe(':props', () => {
     it(':tableData - renders rows', async () => {
       await flushPromises();
 

--- a/tests/components/__snapshots__/TheMangaList.spec.js.snap
+++ b/tests/components/__snapshots__/TheMangaList.spec.js.snap
@@ -3,17 +3,21 @@
 exports[`TheMangaList.vue :props :tableData - renders rows 1`] = `
 <tbody>
   <tr class="el-table__row">
-    <td rowspan="1" colspan="1" class="el-table_1_column_1  ">
+    <td rowspan="1" colspan="1" class="el-table_1_column_1  el-table-column--selection">
+      <div class="cell"><label class="el-checkbox"><span class="el-checkbox__input"><span class="el-checkbox__inner"></span><input type="checkbox" aria-hidden="false" class="el-checkbox__original" value=""></span>
+          <!----></label></div>
+    </td>
+    <td rowspan="1" colspan="1" class="el-table_1_column_2  ">
       <div class="cell"><a href="series.example.url" target="_blank" class="break-normal el-link el-link--default">
           <!----><span class="el-link--inner">Manga Title</span>
           <!----></a></div>
     </td>
-    <td rowspan="1" colspan="1" class="el-table_1_column_2  ">
+    <td rowspan="1" colspan="1" class="el-table_1_column_3  ">
       <div class="cell"><a href="chapter.example.url" target="_blank" class="el-link el-link--default">
           <!----><span class="el-link--inner">10</span>
           <!----></a></div>
     </td>
-    <td rowspan="1" colspan="1" class="el-table_1_column_3  ">
+    <td rowspan="1" colspan="1" class="el-table_1_column_4  ">
       <div class="cell">a year ago</div>
     </td>
   </tr>

--- a/tests/views/MangaList.spec.js
+++ b/tests/views/MangaList.spec.js
@@ -2,6 +2,7 @@ import { shallowMount, createLocalVue } from '@vue/test-utils';
 import { Message } from 'element-ui';
 import flushPromises from 'flush-promises';
 import MangaList from '@/views/MangaList.vue';
+import TheMangaList from '@/components/TheMangaList.vue';
 import * as api from '@/services/api';
 
 const localVue = createLocalVue();
@@ -203,6 +204,63 @@ describe('MangaList.vue', () => {
       await flushPromises();
 
       expect(errorMessageMock).toHaveBeenCalledWith('Something went wrong');
+    });
+  });
+  describe('@events', () => {
+    let mangaList;
+    let mangaSeries;
+
+    beforeEach(() => {
+      mangaList = shallowMount(MangaList, { localVue });
+
+      mangaSeries = {
+        series: {
+          title: 'Manga Title',
+          url: 'https://mangadex.org/manga/24121',
+        },
+        latestChapter: {
+          url: 'chapter.example.url',
+          info: {
+            chapter: '10',
+            title: 'Chapter Title',
+            timestamp: 1522299049,
+          },
+        },
+      };
+
+      mangaList.setData({
+        tableData: [mangaSeries],
+      });
+    });
+
+    it('@seriesSelected - toggles delete button and sets selected series', () => {
+      mangaList.find(TheMangaList).vm.$emit('seriesSelected', [mangaSeries]);
+
+      expect(mangaList.html()).toContain('Remove');
+      expect(mangaList.vm.$data.selectedSeries).toContain(mangaSeries);
+    });
+  });
+  describe(':data', () => {
+    let mangaList;
+    let selectedMangaSeries;
+    let mangaSeries2;
+
+    beforeEach(() => {
+      mangaList = shallowMount(MangaList, { localVue });
+      selectedMangaSeries = { series: { title: 'Manga Title' } };
+      mangaSeries2 = { series: { title: 'Manga Title 2' } };
+
+      mangaList.setData({
+        tableData: [selectedMangaSeries, mangaSeries2],
+        selectedSeries: [selectedMangaSeries],
+      });
+    });
+
+    it(':selectedSeries - if present, can remove them by pressing Remove button', () => {
+      mangaList.vm.removeSeries();
+
+      expect(mangaList.vm.$data.tableData).toHaveLength(1);
+      expect(mangaList.vm.$data.tableData).not.toContain(selectedMangaSeries);
     });
   });
 });


### PR DESCRIPTION
This PR adds the ability to select multiple entries from the manga list, which also shows a Remove button, that will let users remove series they've selected.

Currently it only does it locally, but after back-end starts to persists that data, I will be able to update this to also make a request to remove it on the DB.

![removePreview](https://user-images.githubusercontent.com/4270980/64896992-b1917e80-d679-11e9-8cb0-afe55ef5d698.gif)
