### PR TITLE
Add Authentication

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -26,5 +26,6 @@ module.exports = {
     'jest-watch-typeahead/testname',
   ],
   collectCoverage: true,
+  coveragePathIgnorePatterns: ['/node_modules/', 'src/modules/'],
   coverageReporters: ['lcov', 'text-summary'],
 };

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "vue": "^2.6.10",
     "vue-analytics": "^5.17.2",
     "vue-rollbar": "^1.0.0",
-    "vue-router": "^3.1.3"
+    "vue-router": "^3.1.3",
+    "vuex": "^3.0.1"
   },
   "devDependencies": {
     "@vue/cli-plugin-babel": "^3.9.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "vue-analytics": "^5.17.2",
     "vue-rollbar": "^1.0.0",
     "vue-router": "^3.1.3",
-    "vuex": "^3.0.1"
+    "vuex": "^3.0.1",
+    "vuex-persist": "^2.1.0"
   },
   "devDependencies": {
     "@vue/cli-plugin-babel": "^3.9.0",

--- a/src/components/TheNavigationBar.vue
+++ b/src/components/TheNavigationBar.vue
@@ -5,22 +5,24 @@
     menu-trigger='click'
     router
   )
-    el-menu-item.cursor-default
+    el-menu-item(index='/').border-none
       img.w-32(src='@/assets/logo.svg')
-    el-submenu.avatar-menu.float-right(index='1')
-      template(slot='title')
-        el-avatar.align-middle(
-          src="https://cube.elemecdn.com/0/88/03b0d39583f48206768a7534e55bcpng.png"
-        )
-      el-menu-item.sm_hidden(index='/landing-page') Home
-      el-menu-item.sm_hidden(index='/manga-list') Manga List
-      el-menu-item(disabled) Settings
-      el-menu-item(disabled) Logout
-    el-menu-item.max-sm_hidden.float-right(index='/manga-list') Manga List
-    el-menu-item.max-sm_hidden.float-right(index='/landing-page') Home
+    template(v-if='signedIn')
+      el-submenu.avatar-menu.float-right(index='1')
+        template(slot='title')
+          el-avatar.align-middle(
+            src="https://cube.elemecdn.com/0/88/03b0d39583f48206768a7534e55bcpng.png"
+          )
+        el-menu-item.sm_hidden(index='/manga-list') Manga List
+        el-menu-item(disabled) Settings
+        el-menu-item(@click='signOutMethod') Logout
+      el-menu-item.max-sm_hidden.float-right(index='/manga-list') Manga List
+    template(v-else)
+      el-menu-item.float-right(index='/sign-in') Sign In
 </template>
 
 <script>
+  import { mapGetters, mapActions } from 'vuex';
   import {
     Menu, MenuItem, Avatar, Submenu,
   } from 'element-ui';
@@ -38,8 +40,19 @@
       };
     },
     computed: {
+      ...mapGetters('user', [
+        'signedIn',
+      ]),
       currentPath() {
         return this.$route.path;
+      },
+    },
+    methods: {
+      ...mapActions('user', [
+        'signOut',
+      ]),
+      signOutMethod() {
+        this.signOut().then(() => this.$router.push('/'));
       },
     },
   };

--- a/src/components/TheSignIn.vue
+++ b/src/components/TheSignIn.vue
@@ -1,0 +1,100 @@
+<template lang="pug">
+  el-form(
+    ref='signInForm'
+    :rules='rules'
+    :model='user'
+    label-position='top'
+  )
+    el-form-item(prop='email')
+      el-input(
+        placeholder='Email'
+        type='email'
+        v-model.trim='user.email'
+        prefix-icon="el-icon-user"
+      )
+    el-form-item.mb-3(prop='password')
+      el-input(
+        placeholder='Password'
+        type='password'
+        v-model.trim='user.password'
+        auto-complete='current-password'
+        prefix-icon="el-icon-lock"
+        @keyup.enter.native='submitForm'
+      )
+    el-form-item.mb-0
+      el-checkbox(v-model="remembered") Remember Me (2 months)
+      el-button.w-full(
+        ref='signInSubmit'
+        type='primary'
+        @click='submitForm'
+      ) Sign In
+</template>
+
+<script>
+  import { mapActions, mapGetters } from 'vuex';
+  import {
+    Form, FormItem, Button, Input, Checkbox, Link,
+  } from 'element-ui';
+
+  export default {
+    components: {
+      'el-form': Form,
+      'el-form-item': FormItem,
+      'el-input': Input,
+      'el-button': Button,
+      'el-checkbox': Checkbox,
+      'el-link': Link,
+    },
+    data() {
+      return {
+        user: {
+          email: '',
+          password: '',
+        },
+        remembered: false,
+        rules: {
+          email: [
+            {
+              required: true,
+              message: "Email can't be blank",
+              trigger: 'blur',
+            },
+            {
+              type: 'email',
+              message: 'Please input correct email address',
+              trigger: 'blur',
+            },
+          ],
+          password: [
+            {
+              required: true,
+              message: "Password can't be blank",
+              trigger: 'blur',
+            },
+          ],
+        },
+      };
+    },
+    computed: {
+      ...mapGetters('user', [
+        'signedIn',
+      ]),
+    },
+    methods: {
+      ...mapActions('user', [
+        'signIn',
+      ]),
+      submitForm() {
+        this.$refs.signInForm.validate((valid) => {
+          if (valid) { this.trySignIn(); }
+
+          return false;
+        });
+      },
+      async trySignIn() {
+        await this.signIn(this.user);
+        if (this.signedIn) { this.$router.push({ name: 'manga-list' }); }
+      },
+    },
+  };
+</script>

--- a/src/components/TheSignUp.vue
+++ b/src/components/TheSignUp.vue
@@ -1,0 +1,117 @@
+<template lang="pug">
+  el-form(
+    ref='signUpForm'
+    :rules='rules'
+    :model='user'
+    label-position='top'
+  )
+    el-form-item(prop='email')
+      el-input(placeholder='Email' type='email' v-model.trim='user.email')
+    el-form-item(prop='password')
+      el-input(
+        placeholder='Password'
+        type='password'
+        v-model.trim='user.password'
+        auto-complete='new-password'
+        @keyup.enter.native='submitForm'
+      )
+    el-form-item(prop='password_confirmation')
+      el-input(
+        placeholder='Password confirmation'
+        type='password'
+        v-model.trim='user.password_confirmation'
+        auto-complete='new-password'
+        @keyup.enter.native='signUp(user)'
+      )
+    el-form-item
+      el-button.w-full(
+        ref='signUpSubmit'
+        type='primary'
+        @click='submitForm'
+      ) Sign Up
+</template>
+
+<script>
+  import { mapActions, mapGetters } from 'vuex';
+  import {
+    Form, FormItem, Button, Input,
+  } from 'element-ui';
+
+  export default {
+    components: {
+      'el-form': Form,
+      'el-form-item': FormItem,
+      'el-input': Input,
+      'el-button': Button,
+    },
+    data() {
+      const passwordConfirmationMatches = (rule, value, callback) => {
+        if (!value || value !== this.user.password) {
+          callback(new Error('Passwords do not match.'));
+        } else {
+          callback();
+        }
+      };
+
+      return {
+        user: {
+          email: '',
+          password: '',
+          password_confirmation: '',
+        },
+        rules: {
+          email: [
+            {
+              required: true,
+              message: "Email can't be blank",
+              trigger: 'blur',
+            },
+            {
+              type: 'email',
+              message: 'Please input correct email address',
+              trigger: 'blur,change',
+            },
+          ],
+          password: [
+            {
+              required: true,
+              message: "Password can't be blank",
+              trigger: 'blur',
+            },
+            {
+              min: 8,
+              max: 24,
+              message: 'Password must be between 8 and 24 characters.',
+              trigger: 'change',
+            },
+          ],
+          password_confirmation: [
+            {
+              required: true,
+              message: "Password confirmation can't be blank",
+              trigger: 'change',
+            },
+            { validator: passwordConfirmationMatches, trigger: 'blur' },
+          ],
+        },
+      };
+    },
+    computed: {
+      ...mapGetters('user', [
+        'signedIn',
+      ]),
+    },
+    methods: {
+      ...mapActions('user', [
+        'signUp',
+      ]),
+      submitForm() {
+        this.$refs.signUpForm.validate((valid) => {
+          if (valid) { this.signUp(this.user); }
+
+          return false;
+        });
+      },
+    },
+  };
+</script>

--- a/src/modules/axios.js
+++ b/src/modules/axios.js
@@ -1,0 +1,54 @@
+import axios from 'axios';
+
+const DEV_API_URL = 'http://localhost:3000';
+const PRODUCTION_API_URL = 'https://api.kenmei.co';
+
+const currentEnv = () => (
+  process.env.NODE_ENV === 'production' ? PRODUCTION_API_URL : DEV_API_URL
+);
+
+const logOutFailed = response => response.config.method === 'delete'
+  && response.data.error === 'Signature has expired';
+
+const setAuthConfig = (config) => {
+  const token = localStorage.getItem('access');
+
+  if (token) { config.headers.Authorization = `Bearer ${token}`; }
+
+  return config;
+};
+
+const baseConfig = {
+  baseURL: currentEnv(),
+  headers: {
+    'Content-Type': 'application/json',
+  },
+};
+
+const secure = axios.create(baseConfig);
+const plain  = axios.create(baseConfig);
+
+plain.interceptors.request.use(config => setAuthConfig(config));
+secure.interceptors.request.use(config => setAuthConfig(config));
+secure.interceptors.response.use(null, (error) => {
+  const { response } = error;
+  const { config, status } = response;
+
+  if (response && config && status === 401 && !logOutFailed(response)) {
+    return plain
+      .post('/refresh')
+      .then((response) => {
+        localStorage.access = response.data.access;
+
+        return plain.request(error.response.config);
+      }).catch(() => {
+        delete localStorage.access;
+        delete localStorage.vuex;
+
+        window.location.reload(true);
+      });
+  }
+  return Promise.reject(error);
+});
+
+export { secure, plain };

--- a/src/packs/main.js
+++ b/src/packs/main.js
@@ -8,6 +8,7 @@ import '@/stylesheets/global.scss';
 import '@/stylesheets/tailwind.css';
 
 import router from '@/router';
+import store from '@/store/store';
 
 Vue.config.productionTip = false;
 
@@ -37,5 +38,6 @@ Vue.config.errorHandler = (err, _vm, _info) => { Vue.rollbar.error(err); };
 
 new Vue({
   router,
+  store,
   render: h => h(Home),
 }).$mount('#app');

--- a/src/router.js
+++ b/src/router.js
@@ -1,7 +1,7 @@
-import Vue from 'vue'
-import Router from 'vue-router'
+import Vue from 'vue';
+import Router from 'vue-router';
 
-Vue.use(Router)
+Vue.use(Router);
 
 export default new Router({
   routes: [

--- a/src/router.js
+++ b/src/router.js
@@ -1,5 +1,7 @@
 import Vue from 'vue';
 import Router from 'vue-router';
+import { Message } from 'element-ui';
+import store from '@/store/store';
 
 Vue.use(Router);
 
@@ -7,7 +9,8 @@ export default new Router({
   routes: [
     {
       path: '/',
-      redirect: '/landing-page'
+      name: 'root',
+      component: () => import(/* webpackChunkName: "landing_page" */ './views/LandingPage.vue')
     },
     {
       path: '/manga-list',
@@ -15,16 +18,28 @@ export default new Router({
       // route level code-splitting
       // this generates a separate chunk (about.[hash].js) for this route
       // which is lazy-loaded when the route is visited.
-      component: () => import(/* webpackChunkName: "manga_list" */ './views/MangaList.vue')
+      component: () => import(/* webpackChunkName: "manga_list" */ './views/MangaList.vue'),
+      beforeEnter: (to, from, next) => {
+        if (store.getters["user/signedIn"]) {
+          next();
+        } else {
+          Message.error('Please sign in first');
+          next('/sign-in');
+        }
+      },
     },
     {
       path: '/sign-in',
       name: 'Sign In',
-      component: () => import(/* webpackChunkName: "sign_in" */ './views/SignOn.vue')
+      component: () => import(/* webpackChunkName: "sign_in" */ './views/SignOn.vue'),
+      beforeEnter: (to, from, next) => {
+        if (store.getters["user/signedIn"]) {
+          Message.info('You are already signed in');
+          next('/manga-list');
+        } else {
+          next();
+        }
+      },
     },
-    {
-      path: '/landing-page',
-      component: () => import(/* webpackChunkName: "landing_page" */ './views/LandingPage.vue')
-    }
   ]
 })

--- a/src/router.js
+++ b/src/router.js
@@ -18,6 +18,11 @@ export default new Router({
       component: () => import(/* webpackChunkName: "manga_list" */ './views/MangaList.vue')
     },
     {
+      path: '/sign-in',
+      name: 'Sign In',
+      component: () => import(/* webpackChunkName: "sign_in" */ './views/SignOn.vue')
+    },
+    {
       path: '/landing-page',
       component: () => import(/* webpackChunkName: "landing_page" */ './views/LandingPage.vue')
     }

--- a/src/router.js
+++ b/src/router.js
@@ -15,14 +15,11 @@ export default new Router({
       // route level code-splitting
       // this generates a separate chunk (about.[hash].js) for this route
       // which is lazy-loaded when the route is visited.
-      component: () => import(/* webpackChunkName: "about" */ './views/MangaList.vue')
+      component: () => import(/* webpackChunkName: "manga_list" */ './views/MangaList.vue')
     },
     {
       path: '/landing-page',
-      // route level code-splitting
-      // this generates a separate chunk (about.[hash].js) for this route
-      // which is lazy-loaded when the route is visited.
-      component: () => import(/* webpackChunkName: "about" */ './views/LandingPage.vue')
+      component: () => import(/* webpackChunkName: "landing_page" */ './views/LandingPage.vue')
     }
   ]
 })

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -1,4 +1,4 @@
-import axios from 'axios';
+import { secure } from '@/modules/axios';
 
 const sanitizeManga = (manga) => {
   const newManga = {};
@@ -13,16 +13,16 @@ const sanitizeManga = (manga) => {
 // This can extract both the series and chapter, we want to make use of that
 export const extractSeriesID = url => url.match(/(?!\/)\d+/g);
 
-export const getManga = id => axios
-  .get(`https://api.kenmei.co/api/v1/series/${id}`)
+export const getManga = id => secure
+  .get(`/api/v1/series/${id}`)
   .then((response) => {
     if (response.data.error) { return {}; }
 
     return sanitizeManga(response.data);
   });
 
-export const getMangaBulk = ids => axios
-  .post('https://api.kenmei.co/api/v1/series/bulk', { ids })
+export const getMangaBulk = ids => secure
+  .post('/api/v1/series/bulk', { ids })
   .then((response) => {
     if (response.data.error) { return []; }
 

--- a/src/store/modules/user.js
+++ b/src/store/modules/user.js
@@ -1,0 +1,82 @@
+import { Message, Loading } from 'element-ui';
+import { secure, plain } from '@/modules/axios';
+
+const state = {
+  currentUser: null,
+};
+
+const getters = {
+  signedIn: state => state.currentUser !== null,
+};
+
+const actions = {
+  signIn({ commit }, data) {
+    const loading = Loading.service({ target: '#sign-on-card' });
+
+    return plain.post('/api/v1/sessions/', { user: data })
+      .then((response) => {
+        commit('setCurrentUser', { user_id: response.data.user_id });
+        localStorage.access = response.data.access;
+      })
+      .catch((request) => {
+        if (request.response.data.error === 'User unconfirmed') {
+          Message.info(
+            'Please email hi@kenmei.co to get your account confirmed'
+          );
+        } else {
+          Message.error(request.response.data.error);
+        }
+      })
+      .then(() => { loading.close(); });
+  },
+  signOut({ commit }) {
+    return secure.delete('/api/v1/sessions/')
+      .then(() => {
+        commit('setCurrentUser', null);
+        delete localStorage.access;
+      })
+      .catch((request) => {
+        if (request.response.data.error === 'Signature has expired') {
+          commit('setCurrentUser', null);
+          delete localStorage.access;
+        } else {
+          Message.error(request.response.data.error);
+        }
+      });
+  },
+  signUp({ _commit }, data) {
+    const loading = Loading.service({ target: '#sign-on-card' });
+
+    return plain.post('/api/v1/registrations/', { user: data })
+      .then(() => {
+        Message({
+          message: `Thank you for registering. Please email hi@kenmei.co from
+          the same email to get your account confirmed`,
+          type: 'success',
+          duration: 0,
+          showClose: true,
+        });
+      })
+      .catch((request) => {
+        Message.error({
+          dangerouslyUseHTMLString: true,
+          message: request.response.data,
+        });
+      })
+      .then(() => { loading.close(); });
+  },
+};
+
+const mutations = {
+  setCurrentUser(state, data) {
+    state.currentUser = data;
+  },
+};
+
+export default {
+  namespaced: true,
+  state,
+  getters,
+  actions,
+  mutations,
+};

--- a/src/store/store.js
+++ b/src/store/store.js
@@ -1,0 +1,17 @@
+import Vue from 'vue';
+import Vuex from 'vuex';
+import VuexPersist from 'vuex-persist';
+import user from './modules/user';
+
+Vue.use(Vuex);
+
+const vuexLocalStorage = new VuexPersist({
+  modules: ['user'],
+});
+
+export default new Vuex.Store({
+  modules: {
+    user,
+  },
+  plugins: [vuexLocalStorage.plugin],
+});

--- a/src/views/SignOn.vue
+++ b/src/views/SignOn.vue
@@ -1,0 +1,32 @@
+<template lang="pug">
+  .container.mx-auto.w-full.h-full
+    .flex.flex-col.h-full.w-full.items-center.justify-center
+      .w-full.max-w-xs.mt-16.rounded.overflow-hidden.shadow-lg.bg-white
+        .px-6.py-4#sign-on-card
+          el-tabs(v-model="activeTab" stretch)
+            el-tab-pane(label="Sign In" name="signIn")
+              the-sign-in
+            el-tab-pane(label="Sign Up" name="signUp")
+              the-sign-up
+</template>
+
+<script>
+  import { Tabs, TabPane } from 'element-ui';
+
+  import TheSignIn from '@/components/TheSignIn';
+  import TheSignUp from '@/components/TheSignUp';
+
+  export default {
+    components: {
+      TheSignIn,
+      TheSignUp,
+      'el-tabs': Tabs,
+      'el-tab-pane': TabPane,
+    },
+    data() {
+      return {
+        activeTab: 'signIn',
+      };
+    },
+  };
+</script>

--- a/tests/components/TheSignIn.spec.js
+++ b/tests/components/TheSignIn.spec.js
@@ -1,0 +1,47 @@
+import { mount, createLocalVue } from '@vue/test-utils';
+import Vuex from 'vuex';
+
+import TheSignIn from '@/components/TheSignIn.vue';
+
+import user from '@/store/modules/user';
+
+const localVue = createLocalVue();
+
+localVue.use(Vuex);
+
+describe('TheSignIn.vue', () => {
+  describe(':props', () => {
+    let signIn;
+    let store;
+
+    beforeEach(() => {
+      store = new Vuex.Store({
+        modules: {
+          user: {
+            namespaced: true,
+            state: user.state,
+            actions: user.actions,
+            getters: user.getters,
+          },
+        },
+      });
+
+      signIn = mount(TheSignIn, {
+        store,
+        localVue,
+      });
+    });
+
+    it.skip('delegates to store to sign in user if form is valid', async () => {
+      signIn.setData({ email: 'text@example.com', password: 'password' });
+
+      signIn.find({ ref: 'signInSubmit' }).trigger('click');
+    });
+
+    it('shows validation errors if form is invalid', () => {
+      signIn.find({ ref: 'signInSubmit' }).trigger('click');
+
+      expect(signIn.text()).toContain("Password can't be blank");
+    });
+  });
+});

--- a/tests/components/TheSignUp.spec.js
+++ b/tests/components/TheSignUp.spec.js
@@ -1,0 +1,73 @@
+import { mount, createLocalVue } from '@vue/test-utils';
+import Vuex from 'vuex';
+
+import TheSignUp from '@/components/TheSignUp.vue';
+
+import user from '@/store/modules/user';
+
+const localVue = createLocalVue();
+
+localVue.use(Vuex);
+
+describe('TheSignUp.vue', () => {
+  describe(':data', () => {
+    let signUp;
+    let store;
+
+    beforeEach(() => {
+      store = new Vuex.Store({
+        modules: {
+          user: {
+            namespaced: true,
+            state: user.state,
+            actions: {
+              signUp: jest.fn(),
+            },
+            getters: user.getters,
+          },
+        },
+      });
+
+      signUp = mount(TheSignUp, {
+        store,
+        localVue,
+      });
+    });
+
+    describe(':user - is valid', () => {
+      beforeEach(() => {
+        signUp.setData({
+          email: 'text@example.com',
+          password: 'password',
+          password_confirmation: 'password',
+        });
+      });
+
+      it.skip('delegates to store to sign in user if form is valid', async () => {
+        signUp.find({ ref: 'signUpSubmit' }).trigger('click');
+      });
+    });
+
+    describe(':user - is invalid', () => {
+      it('shows validation errors if form is invalid', () => {
+        signUp.find({ ref: 'signUpSubmit' }).trigger('click');
+
+        expect(signUp.text()).toContain("Email can't be blank");
+      });
+
+      it('tests that passwords match each other', () => {
+        signUp.setData({
+          user: {
+            email: 'text@example.com',
+            password: 'pass',
+            password_confirmation: 'passwo',
+          },
+        });
+
+        signUp.find({ ref: 'signUpSubmit' }).trigger('click');
+
+        expect(signUp.text()).toContain('Passwords do not match');
+      });
+    });
+  });
+});

--- a/tests/store/modules/user.spec.js
+++ b/tests/store/modules/user.spec.js
@@ -1,0 +1,204 @@
+import axios from 'axios';
+import flushPromises from 'flush-promises';
+import { Message } from 'element-ui';
+import user from '@/store/modules/user';
+
+describe('user', () => {
+  describe('getters', () => {
+    describe('signedIn', () => {
+      it('returns true if current user is set', () => {
+        const state = { currentUser: jest.fn() };
+
+        expect(user.getters.signedIn(state)).toBeTruthy();
+      });
+    });
+  });
+
+  describe('mutations', () => {
+    describe('setCurrentUser', () => {
+      it('sets current user state', () => {
+        const newUser = { user_id: 1 };
+        const state = { currentUser: null };
+
+        user.mutations.setCurrentUser(state, newUser);
+
+        expect(state).toEqual({ currentUser: newUser });
+      });
+    });
+  });
+
+  describe('actions', () => {
+    let commit;
+
+    beforeEach(() => {
+      commit = jest.fn();
+    });
+
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
+    describe('signIn', () => {
+      it('sends credentials and sets current user with access token', async () => {
+        const axiosSpy = jest.spyOn(axios, 'post');
+        const mockData = { email: 'test@example.com', password: 'password' };
+        const mockResponse = { access: '123.abc.jwt', user_id: 1 };
+
+        axiosSpy.mockResolvedValue({ status: 200, data: mockResponse });
+
+        user.actions.signIn({ commit }, mockData);
+
+        await flushPromises();
+
+        expect(axiosSpy).toHaveBeenCalledWith(
+          '/api/v1/sessions/',
+          { user: mockData }
+        );
+        expect(commit).toHaveBeenCalledWith(
+          'setCurrentUser', { user_id: mockResponse.user_id }
+        );
+      });
+
+      it('raises Message error if server returns unauthorized', async () => {
+        const axiosSpy        = jest.spyOn(axios, 'post');
+        const errorMessageSpy = jest.spyOn(Message, 'error');
+
+        const mockData = {
+          email: 'test@example.com',
+          password: 'wrong_password',
+        };
+        const mockResponse = {
+          response: { data: { error: 'Invalid email or password' } },
+        };
+
+        axiosSpy.mockRejectedValue(mockResponse);
+
+        user.actions.signIn({ commit }, mockData);
+
+        await flushPromises();
+
+        expect(commit).not.toHaveBeenCalledWith('setCurrentUser');
+        expect(errorMessageSpy).toHaveBeenLastCalledWith(
+          mockResponse.response.data.error
+        );
+      });
+
+      it('shows confirmation info message if server returns unconfirmed', async () => {
+        const axiosSpy       = jest.spyOn(axios, 'post');
+        const infoMessageSpy = jest.spyOn(Message, 'info');
+
+        const mockData = { email: 'test@example.com', password: 'password' };
+        const mockResponse = {
+          response: { data: { error: 'User unconfirmed' } },
+        };
+
+        axiosSpy.mockRejectedValue(mockResponse);
+
+        user.actions.signIn({ commit }, mockData);
+
+        await flushPromises();
+
+        expect(commit).not.toHaveBeenCalledWith('setCurrentUser');
+        expect(infoMessageSpy).toHaveBeenLastCalledWith(
+          'Please email hi@kenmei.co to get your account confirmed'
+        );
+      });
+    });
+
+    describe('signOut', () => {
+      it('logs out user and resets access token and current user', async () => {
+        const axiosSpy = jest.spyOn(axios, 'delete');
+
+        axiosSpy.mockResolvedValue();
+
+        user.actions.signOut({ commit });
+
+        await flushPromises();
+
+        expect(axiosSpy).toHaveBeenCalledWith('/api/v1/sessions/');
+        expect(commit).toHaveBeenCalledWith('setCurrentUser', null);
+      });
+
+      it('logs user out if the token has expired', async () => {
+        const axiosSpy = jest.spyOn(axios, 'delete');
+
+        const mockResponse = {
+          response: { data: { error: 'Signature has expired' } },
+        };
+
+        axiosSpy.mockRejectedValue(mockResponse);
+
+        user.actions.signOut({ commit });
+
+        await flushPromises();
+
+        expect(axiosSpy).toHaveBeenCalledWith('/api/v1/sessions/');
+        expect(commit).toHaveBeenCalledWith('setCurrentUser', null);
+      });
+
+      it('raises Message error if get request failed', async () => {
+        const axiosSpy         = jest.spyOn(axios, 'delete');
+        const errorMessageMock = jest.spyOn(Message, 'error');
+
+        const mockResponse = {
+          response: { data: { error: 'Some other error' } },
+        };
+
+        axiosSpy.mockRejectedValue(mockResponse);
+
+        user.actions.signOut({ commit });
+
+        await flushPromises();
+
+        expect(commit).not.toHaveBeenCalledWith('setCurrentUser');
+        expect(errorMessageMock).toHaveBeenLastCalledWith(
+          mockResponse.response.data.error
+        );
+      });
+    });
+
+    describe('signUp', () => {
+      it('POSTs to registrations endpoint and show confirmation message', async () => {
+        const axiosSpy = jest.spyOn(axios, 'post');
+        const mockData = {
+          email: 'test@example.com',
+          password: 'password',
+          password_confirmation: 'password',
+        };
+
+        axiosSpy.mockResolvedValue({ status: 200 });
+
+        user.actions.signUp({ commit }, mockData);
+
+        await flushPromises();
+
+        expect(axiosSpy).toHaveBeenCalledWith(
+          '/api/v1/registrations/',
+          { user: mockData }
+        );
+      });
+
+      it('shows server-side errors if request failed', async () => {
+        const axiosSpy        = jest.spyOn(axios, 'post');
+        const errorMessageSpy = jest.spyOn(Message, 'error');
+
+        const mockData     = { email: 'test@example.com' };
+        const mockResponse = {
+          response: {
+            data: 'Missing password<br>Missing password confirmation',
+          },
+        };
+
+        axiosSpy.mockRejectedValue(mockResponse);
+
+        user.actions.signUp({ commit }, mockData);
+
+        await flushPromises();
+
+        expect(commit).not.toHaveBeenCalledWith('setCurrentUser');
+        // TODO: Check that we actually called it with server-side errors
+        expect(errorMessageSpy).toBeCalled();
+      });
+    });
+  });
+});

--- a/tests/views/SignOn.spec.js
+++ b/tests/views/SignOn.spec.js
@@ -1,0 +1,8 @@
+import { shallowMount } from '@vue/test-utils';
+import SignOn from '@/views/SignOn.vue';
+
+describe('SignOn.vue', () => {
+  it('renders the page', () => {
+    expect(shallowMount(SignOn).element).toMatchSnapshot();
+  });
+});

--- a/tests/views/__snapshots__/SignOn.spec.js.snap
+++ b/tests/views/__snapshots__/SignOn.spec.js.snap
@@ -1,0 +1,39 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`SignOn.vue renders the page 1`] = `
+<div
+  class="container mx-auto w-full h-full"
+>
+  <div
+    class="flex flex-col h-full w-full items-center justify-center"
+  >
+    <div
+      class="w-full max-w-xs mt-16 rounded overflow-hidden shadow-lg bg-white"
+    >
+      <div
+        class="px-6 py-4"
+        id="sign-on-card"
+      >
+        <el-tabs-stub
+          stretch="true"
+          tabposition="top"
+          value="signIn"
+        >
+          <el-tab-pane-stub
+            label="Sign In"
+            name="signIn"
+          >
+            <the-sign-in-stub />
+          </el-tab-pane-stub>
+          <el-tab-pane-stub
+            label="Sign Up"
+            name="signUp"
+          >
+            <the-sign-up-stub />
+          </el-tab-pane-stub>
+        </el-tabs-stub>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/yarn.lock
+++ b/yarn.lock
@@ -6451,6 +6451,11 @@ lodash.memoize@^4.1.2:
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
   integrity sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=
 
+lodash.merge@^4.6.2:
+  version "4.6.2"
+  resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
+  integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
+
 lodash.sortby@^4.7.0:
   version "4.7.0"
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
@@ -10372,6 +10377,14 @@ vue@^2.6.10:
   version "2.6.10"
   resolved "https://registry.yarnpkg.com/vue/-/vue-2.6.10.tgz#a72b1a42a4d82a721ea438d1b6bf55e66195c637"
   integrity sha512-ImThpeNU9HbdZL3utgMCq0oiMzAkt1mcgy3/E6zWC/G6AaQoeuFdsl9nDhTDU3X1R6FK7nsIUuRACVcjI+A2GQ==
+
+vuex-persist@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/vuex-persist/-/vuex-persist-2.1.0.tgz#16b549aace89892e8cf6f9e2bca457008df2a677"
+  integrity sha512-H9RqXHeynBQG60rUrsinYNLoRFXkSxh2Xx8kTVFuvLRQ9jZd3HLMvm713m2r1dN/pVZBUgiIzTu6uj5hBsAOqg==
+  dependencies:
+    flatted "^2.0.0"
+    lodash.merge "^4.6.2"
 
 vuex@^3.0.1:
   version "3.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10373,6 +10373,11 @@ vue@^2.6.10:
   resolved "https://registry.yarnpkg.com/vue/-/vue-2.6.10.tgz#a72b1a42a4d82a721ea438d1b6bf55e66195c637"
   integrity sha512-ImThpeNU9HbdZL3utgMCq0oiMzAkt1mcgy3/E6zWC/G6AaQoeuFdsl9nDhTDU3X1R6FK7nsIUuRACVcjI+A2GQ==
 
+vuex@^3.0.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/vuex/-/vuex-3.1.1.tgz#0c264bfe30cdbccf96ab9db3177d211828a5910e"
+  integrity sha512-ER5moSbLZuNSMBFnEBVGhQ1uCBNJslH9W/Dw2W7GZN23UQA69uapP5GTT9Vm8Trc0PzBSVt6LzF3hGjmv41xcg==
+
 w3c-hr-time@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/w3c-hr-time/-/w3c-hr-time-1.0.1.tgz#82ac2bff63d950ea9e3189a58a65625fedf19045"


### PR DESCRIPTION
This PR adds secure authentication using JSON Web Tokens. With this work, anybody can sign up for a new account with username and password. 

Most endpoints will now be authenticatable, so the account is required to access those. There is plenty of outstanding work to improve upon this, detailed below, but this provides basic, secure authentication that I can work on top.

Currently, signup requires manually sending me an email, so I can confirm it. I'd like to start off slow, with manual confirmation as we ramp up, but this will eventually be an automatic process of course.

## Sign in view
| Sign In | Sign In validations |
| --- | --- |
| <img width="300" alt="Screen Shot 2019-09-15 at 15 40 46" src="https://user-images.githubusercontent.com/4270980/64923163-41950c80-d7cf-11e9-9a44-26918c4d2953.png"> | <img width="300" alt="Screen Shot 2019-09-15 at 15 40 46" src="https://user-images.githubusercontent.com/4270980/64923174-570a3680-d7cf-11e9-9b7d-f993375bf973.png"> |

## Sign up view
| Sign In | Sign In validations |
| --- | --- |
| <img width="500" alt="Screen Shot 2019-09-15 at 15 40 46" src="https://user-images.githubusercontent.com/4270980/64923167-49ed4780-d7cf-11e9-8b69-1d57dece6efb.png"> | <img width="353" alt="Screen Shot 2019-09-15 at 15 40 51" src="https://user-images.githubusercontent.com/4270980/64923192-7acd7c80-d7cf-11e9-97fa-47ab17a6aa38.png"> |


## Outstanding work to be done later
- [ ] Able to update user details
- [ ] Able to delete the account
- [ ] Having to confirm email before getting access to the app after sign up
- [ ] Reset password functionality