### PR TITLE
Better axios mocking

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "dayjs": "^1.8.16",
     "element-ui": "^2.12.0",
     "he": "^1.2.0",
+    "jest-mock-axios": "^3.1.1",
     "p-limit": "^2.2.1",
     "pug-plain-loader": "^1.0.0",
     "vue": "^2.6.10",

--- a/tests/__mocks__/axios.js
+++ b/tests/__mocks__/axios.js
@@ -1,0 +1,3 @@
+import mockAxios from 'jest-mock-axios';
+
+export default mockAxios;

--- a/tests/services/api.spec.js
+++ b/tests/services/api.spec.js
@@ -1,8 +1,6 @@
 import axios from 'axios';
 import * as apiService from '@/services/api';
 
-jest.mock('axios');
-
 describe('API', () => {
   describe('extractSeriesID()', () => {
     it('extracts an ID from a MangaDex series or chapter URL', () => {
@@ -16,7 +14,7 @@ describe('API', () => {
   });
 
   describe('getManga()', () => {
-    it('makes a request to the API and returns manga if found', () => {
+    it('makes a request to the API and returns manga if found', async () => {
       const mockData = {
         title: 'Manga Title',
         url: 'series.example.url',
@@ -30,33 +28,29 @@ describe('API', () => {
         },
       };
 
-      axios.get.mockImplementationOnce(
-        () => Promise.resolve({ status: 200, data: mockData })
-      );
+      axios.get.mockResolvedValue({ status: 200, data: mockData });
 
-      apiService.getManga('123').then((data) => {
-        expect(data).toEqual(
-          {
-            series: { title: mockData.title, url: mockData.url },
-            latestChapter: mockData.latestChapter,
-          }
-        );
-      });
+      const data = await apiService.getManga('123');
+      expect(data).toEqual(
+        {
+          series: { title: mockData.title, url: mockData.url },
+          latestChapter: mockData.latestChapter,
+        }
+      );
     });
 
-    it('makes a request to the API and returns empty object if not found', () => {
-      axios.get.mockImplementationOnce(
-        () => Promise.resolve({ status: 200, data: { error: 'not_found' } })
-      );
-
-      apiService.getManga('123').then((data) => {
-        expect(data).toEqual({});
+    it('makes a request to the API and returns empty object if not found', async () => {
+      axios.get.mockResolvedValue({
+        status: 200, data: { error: 'not_found' }
       });
+
+      const data = await apiService.getManga('123');
+      expect(data).toEqual({});
     });
   });
 
   describe('getMangaBulk()', () => {
-    it('makes a request to the API bulk endpoint and delegate to sanitizeManga', () => {
+    it('makes a request to the API bulk endpoint and delegate to sanitizeManga', async () => {
       const mockData = {
         successful: {
           1: {
@@ -89,19 +83,17 @@ describe('API', () => {
 
       axios.post.mockResolvedValue({ status: 200, data: mockData });
 
-      apiService.getMangaBulk('1 2 3').then((data) => {
-        expect(data.length).toBe(2);
-      });
+      const data = await apiService.getMangaBulk('1 2 3');
+      expect(data.length).toEqual(2);
     });
 
-    it('makes a request to the API and returns empty object if not found', () => {
+    it('makes a request to the API and returns empty object if not found', async () => {
       axios.post.mockResolvedValue({
         status: 200, data: { error: 'not_found' },
       });
 
-      apiService.getMangaBulk('1 2 3').then((data) => {
-        expect(data).toEqual([]);
-      });
+      const data = await apiService.getMangaBulk('1 2 3');
+      expect(data).toEqual([]);
     });
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -5911,6 +5911,13 @@ jest-message-util@^23.4.0:
     slash "^1.0.0"
     stack-utils "^1.0.1"
 
+jest-mock-axios@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/jest-mock-axios/-/jest-mock-axios-3.1.1.tgz#e8776c06a929b11ee8861c6a24dcf5ca7926f03a"
+  integrity sha512-3GCDj4aMk9+tRbU4wKZCHrewMdmyI/SuNF/2/ezzxRNAct+herwvy44Seeq7iLTAeFBiuEcL7gVfyf4TV+hUwg==
+  dependencies:
+    synchronous-promise "^2.0.10"
+
 jest-mock@^23.2.0:
   version "23.2.0"
   resolved "https://registry.yarnpkg.com/jest-mock/-/jest-mock-23.2.0.tgz#ad1c60f29e8719d47c26e1138098b6d18b261134"
@@ -9673,6 +9680,11 @@ symbol-tree@^3.2.2:
   version "3.2.4"
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.4.tgz#430637d248ba77e078883951fb9aa0eed7c63fa2"
   integrity sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==
+
+synchronous-promise@^2.0.10:
+  version "2.0.10"
+  resolved "https://registry.yarnpkg.com/synchronous-promise/-/synchronous-promise-2.0.10.tgz#e64c6fd3afd25f423963353043f4a68ebd397fd8"
+  integrity sha512-6PC+JRGmNjiG3kJ56ZMNWDPL8hjyghF5cMXIFOKg+NiwwEZZIvxTWd0pinWKyD227odg9ygF8xVhhz7gb8Uq7A==
 
 table@4.0.2:
   version "4.0.2"


### PR DESCRIPTION
This PR adds jest-mock-axios package, which properly mocks axios.  I also refactor API service spec, to use `async/wait` to resolve data, as otherwise it's easy to see errors swallowed inside `then`.