### PR TITLE
Fix Rollbar not actually tracking JS errors

### DIFF
--- a/src/packs/main.js
+++ b/src/packs/main.js
@@ -33,6 +33,8 @@ Vue.use(Rollbar, {
   },
 });
 
+Vue.config.errorHandler = (err, _vm, _info) => { Vue.rollbar.error(err); };
+
 new Vue({
   router,
   render: h => h(Home),


### PR DESCRIPTION
Even though I added Rollbar tracking, I didn't actually add the right hook to catch any exceptions. This PR fixes that