### PR TITLE
Add full height and overflow to home div

### DIFF
--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -1,5 +1,5 @@
 <template lang="pug">
-  #home
+  #home.h-full.overflow-auto
     navigation-bar
     router-view
 </template>


### PR DESCRIPTION
I didn't realise that removing `h-full` from `#home` would mess up the vertical alignment on the sign-in and landing page. But on its own, it also didn't fully wrap the page, which is why I am also adding `overflow-auto`