### PR TITLE
Update existing manga check to do exact matching

### DIFF
--- a/src/services/api.js
+++ b/src/services/api.js
@@ -1,7 +1,7 @@
 import { secure } from '@/modules/axios';
 
 // This can extract both the series and chapter, we want to make use of that
-export const extractSeriesID = url => url.match(/(?!\/)\d+/g);
+export const extractSeriesID = url => url.match(/(?!\/)\d+/g)[0];
 
 export const addMangaEntry = (seriesURL, mangaListID) => secure
   .post('/api/v1/manga_entries/', {

--- a/src/store/modules/lists.js
+++ b/src/store/modules/lists.js
@@ -1,6 +1,8 @@
 import { Message } from 'element-ui';
 import { secure } from '@/modules/axios';
 
+import { extractSeriesID } from '@/services/api';
+
 const state = {
   lists: [],
   entries: [],
@@ -11,8 +13,8 @@ const getters = {
   getEntriesByListId: state => listID => state.entries.filter(
     entry => entry.relationships.manga_list.data.id === listID
   ),
-  entryAlreadyExists: state => mangaID => state.entries.some(
-    manga => manga.links.series_url.includes(mangaID)
+  entryAlreadyExists: state => mangaURL => state.entries.some(
+    manga => extractSeriesID(manga.links.series_url) === extractSeriesID(mangaURL)
   ),
 };
 

--- a/src/views/MangaList.vue
+++ b/src/views/MangaList.vue
@@ -107,7 +107,7 @@
   import TheMangaList from '@/components/TheMangaList';
   import ProgressBar from '@/components/ProgressBar';
   import {
-    addMangaEntry, addMangaEntries, deleteMangaEntry, extractSeriesID,
+    addMangaEntry, addMangaEntries, deleteMangaEntry,
   } from '@/services/api';
   import { processList, sliceIntoBatches } from '@/services/importer';
 
@@ -170,7 +170,7 @@
         this.removeEntries(this.selectedSeriesIDs);
       },
       mangaDexSearch() {
-        if (this.alreadyExists(this.mangaURL)) {
+        if (this.entryAlreadyExists(this.mangaURL)) {
           Message.info('Manga already added');
           this.dialogVisible = false;
           return;
@@ -200,11 +200,6 @@
         loading.close();
         this.mangaURL = '';
       },
-      alreadyExists(mangaURL) {
-        // TODO: We want to save and send back MangaDex ID from back-end
-        const mangaID = extractSeriesID(mangaURL);
-        return this.entryAlreadyExists(mangaID);
-      },
       processMangaDexList(list) {
         let seriesImported  = 0;
         const filteredLists = {};
@@ -217,7 +212,7 @@
               seriesURL: url.full_title_url,
               lastRead: url.title_data.current_chapter,
             }))
-            .filter(url => !this.alreadyExists(url.seriesURL));
+            .filter(url => !this.entryAlreadyExists(url.seriesURL));
         });
 
         if (Object.values(filteredLists).every(list => list.length === 0)) {

--- a/tests/services/api.spec.js
+++ b/tests/services/api.spec.js
@@ -12,10 +12,10 @@ describe('API', () => {
     it('extracts an ID from a MangaDex series or chapter URL', () => {
       expect(
         apiService.extractSeriesID('https://mangadex.org/chapter/671525')
-      ).toEqual(['671525']);
+      ).toEqual('671525');
       expect(
         apiService.extractSeriesID('https://mangadex.org/title/65')
-      ).toEqual(['65']);
+      ).toEqual('65');
     });
   });
 

--- a/tests/store/modules/lists.spec.js
+++ b/tests/store/modules/lists.spec.js
@@ -31,11 +31,17 @@ describe('lists', () => {
 
     describe('entryAlreadyExists', () => {
       it('returns entries based on a list id', () => {
-        const state = { entries: mangaEntryFactory.buildList(1) };
+        const state = {
+          entries: mangaEntryFactory.buildList(
+            1,
+            { links: { series_url: 'example.url/manga/12' } }
+          ),
+        };
 
         const entryAlreadyExists = lists.getters.entryAlreadyExists(state);
 
-        expect(entryAlreadyExists('example.url/manga/1')).toBeTruthy();
+        expect(entryAlreadyExists('example.url/manga/12')).toBeTruthy();
+        expect(entryAlreadyExists('example.url/manga/1')).not.toBeTruthy();
         expect(entryAlreadyExists('example.url/manga/2')).not.toBeTruthy();
       });
     });


### PR DESCRIPTION
This PR fixes #57 issue, by updating how I am checking for the existing series on the client-side. 

I was doing a substring check on the manga URL, instead of matching directly. Hence providing a URL like this `https://mangadex.org/manga/6` would match any series that contain a `6`, for example: `https://mangadex.org/manga/621`

Instead, I use ID extracting regex on both URLs and only if they match directly, would I mark a manga as existing.