### PR TITLE
Improve empty chapter handling

### DIFF
--- a/src/components/TheMangaList.vue
+++ b/src/components/TheMangaList.vue
@@ -38,9 +38,13 @@
       prop="attributes.last_released_at"
       label="Released"
       sortable
+      :sort-method="releasedAtSort"
     )
       template(v-if='scope.row.attributes' slot-scope="scope")
-        | {{ scope.row.attributes.last_released_at | timeAgo }}
+        template(v-if='scope.row.attributes.last_released_at')
+          | {{ scope.row.attributes.last_released_at | timeAgo }}
+        template(v-else)
+          | Unknown
 </template>
 
 <script>
@@ -78,6 +82,15 @@
       ]),
     },
     methods: {
+      releasedAtSort(a, b) {
+        const aReleasedAt = a.attributes.last_released_at;
+        const bReleasedAt = b.attributes.last_released_at;
+
+        // Descending order, with null always being the oldest
+        return (aReleasedAt === null) - (bReleasedAt === null)
+          || -(aReleasedAt > bReleasedAt)
+          || +(aReleasedAt < bReleasedAt);
+      },
       handleSelectionChange(val) {
         const ids = val.map(entry => entry.id);
         this.$emit('seriesSelected', ids);

--- a/src/components/TheMangaList.vue
+++ b/src/components/TheMangaList.vue
@@ -26,11 +26,14 @@
     )
       template(v-if='scope.row.attributes' slot-scope="scope")
         el-link(
+          v-if="scope.row.links.last_chapter_available_url"
           :href="scope.row.links.last_chapter_available_url"
           :underline="false"
           target="_blank"
         )
           | {{ scope.row.attributes.last_chapter_available }}
+        template(v-else)
+          | No chapters
     el-table-column(
       prop="attributes.last_released_at"
       label="Released"

--- a/src/components/TheMangaList.vue
+++ b/src/components/TheMangaList.vue
@@ -40,7 +40,7 @@
       sortable
     )
       template(v-if='scope.row.attributes' slot-scope="scope")
-        | {{ releasedAt(scope.row.attributes.last_released_at) }}
+        | {{ scope.row.attributes.last_released_at | timeAgo }}
 </template>
 
 <script>
@@ -62,6 +62,9 @@
       sanitize(title) {
         return he.decode(title);
       },
+      timeAgo(datetime) {
+        return dayjs().to(dayjs(datetime));
+      },
     },
     props: {
       tableData: {
@@ -75,9 +78,6 @@
       ]),
     },
     methods: {
-      releasedAt(datetime) {
-        return dayjs().to(dayjs(datetime));
-      },
       handleSelectionChange(val) {
         const ids = val.map(entry => entry.id);
         this.$emit('seriesSelected', ids);

--- a/tests/components/TheMangaList.spec.js
+++ b/tests/components/TheMangaList.spec.js
@@ -29,7 +29,7 @@ describe('TheMangaList.vue', () => {
       localVue,
       sync: false,
       propsData: {
-        tableData: [mangaEntryFactory.build()],
+        tableData: mangaEntryFactory.buildList(1),
       },
     });
   });
@@ -44,6 +44,36 @@ describe('TheMangaList.vue', () => {
     });
   });
 
+  describe('when no last chapter is available', () => {
+    it('Released at column shows Unknown', async () => {
+      mangaList.setProps({
+        tableData: [
+          mangaEntryFactory.build(
+            { attributes: { title: 'Manga Title', last_released_at: null } }
+          ),
+        ],
+      });
+
+      await flushPromises();
+
+      expect(mangaList.text()).toContain('Unknown');
+    });
+
+    it('Latest Chapter column shows no chapters', async () => {
+      mangaList.setProps({
+        tableData: [
+          mangaEntryFactory.build(
+            { links: { last_chapter_available_url: null } }
+          ),
+        ],
+      });
+
+      await flushPromises();
+
+      expect(mangaList.text()).toContain('No chapters');
+    });
+  });
+
   describe(':props', () => {
     it(':tableData - renders rows', async () => {
       await flushPromises();
@@ -51,6 +81,51 @@ describe('TheMangaList.vue', () => {
       const table = mangaList.find('tbody');
 
       expect(table.html()).toMatchSnapshot();
+    });
+
+    // TODO: Can't get ElementUI table to trigger sorting on click
+    // When I figure that out, update this test to actually work
+    it.skip(':tableData - sorting Released at shows Unknown last', async () => {
+      mangaList.setProps({
+        tableData: [
+          mangaEntryFactory.build(
+            {
+              attributes: { title: 'Manga Title Last', last_released_at: null },
+            }
+          ),
+          mangaEntryFactory.build(
+            {
+              attributes: {
+                title: 'Manga Title Middle',
+                last_released_at: '2019-01-01T00:00:00.000Z',
+              },
+            }
+          ),
+          mangaEntryFactory.build(
+            {
+              attributes: {
+                title: 'Manga Title First',
+                last_released_at: '2019-01-10T00:00:00.000Z',
+              },
+            }
+          ),
+        ],
+      });
+
+      await flushPromises();
+
+      const releasedAt = mangaList.find('.el-table_1_column_5').find('.cell');
+      const tableRows  = mangaList.findAll('.el-table__row');
+
+      releasedAt.trigger('click');
+
+      expect(tableRows.at(0).text()).toContain('10 months ago');
+      expect(tableRows.at(2).text()).toContain('Unknown');
+
+      releasedAt.trigger('click');
+
+      expect(tableRows.at(0).text()).toContain('Unknown');
+      expect(tableRows.at(2).text()).toContain('10 months ago');
     });
 
     it(':tableData - sanitizes manga title to convert special characters', async () => {
@@ -63,34 +138,6 @@ describe('TheMangaList.vue', () => {
       await flushPromises();
 
       expect(mangaList.find('.el-link--inner').text()).toContain('Übel Blatt');
-    });
-
-    it(':tableData - shows Released at as Unknown if no timestamp availiable', async () => {
-      mangaList.setProps({
-        tableData: [
-          mangaEntryFactory.build(
-            { attributes: { last_released_at: null } }
-          ),
-        ],
-      });
-
-      await flushPromises();
-
-      expect(mangaList.find('.el-link--inner').text()).toContain('Unknown');
-    });
-
-    it(':tableData - shows Released at as Unknown if no latest chapters availiable', async () => {
-      mangaList.setProps({
-        tableData: [
-          mangaEntryFactory.build(
-            { links: { last_chapter_available_url: null } }
-          ),
-        ],
-      });
-
-      await flushPromises();
-
-      expect(mangaList.find('.el-link--inner').text()).toContain('No chapters');
     });
   });
 });

--- a/tests/components/TheMangaList.spec.js
+++ b/tests/components/TheMangaList.spec.js
@@ -65,6 +65,20 @@ describe('TheMangaList.vue', () => {
       expect(mangaList.find('.el-link--inner').text()).toContain('Übel Blatt');
     });
 
+    it(':tableData - shows Released at as Unknown if no timestamp availiable', async () => {
+      mangaList.setProps({
+        tableData: [
+          mangaEntryFactory.build(
+            { attributes: { last_released_at: null } }
+          ),
+        ],
+      });
+
+      await flushPromises();
+
+      expect(mangaList.find('.el-link--inner').text()).toContain('Unknown');
+    });
+
     it(':tableData - shows Released at as Unknown if no latest chapters availiable', async () => {
       mangaList.setProps({
         tableData: [

--- a/tests/components/TheMangaList.spec.js
+++ b/tests/components/TheMangaList.spec.js
@@ -64,5 +64,19 @@ describe('TheMangaList.vue', () => {
 
       expect(mangaList.find('.el-link--inner').text()).toContain('Übel Blatt');
     });
+
+    it(':tableData - shows Released at as Unknown if no latest chapters availiable', async () => {
+      mangaList.setProps({
+        tableData: [
+          mangaEntryFactory.build(
+            { links: { last_chapter_available_url: null } }
+          ),
+        ],
+      });
+
+      await flushPromises();
+
+      expect(mangaList.find('.el-link--inner').text()).toContain('No chapters');
+    });
   });
 });

--- a/tests/components/__snapshots__/TheMangaList.spec.js.snap
+++ b/tests/components/__snapshots__/TheMangaList.spec.js.snap
@@ -3,24 +3,24 @@
 exports[`TheMangaList.vue :props :tableData - renders rows 1`] = `
 <tbody>
   <tr class="el-table__row">
-    <td rowspan="1" colspan="1" class="el-table_1_column_1  el-table-column--selection">
+    <td rowspan="1" colspan="1" class="el-table_3_column_11  el-table-column--selection">
       <div class="cell"><label class="el-checkbox"><span class="el-checkbox__input"><span class="el-checkbox__inner"></span><input type="checkbox" aria-hidden="false" class="el-checkbox__original" value=""></span>
           <!----></label></div>
     </td>
-    <td rowspan="1" colspan="1" class="el-table_1_column_2  ">
+    <td rowspan="1" colspan="1" class="el-table_3_column_12  ">
       <div class="cell"><a href="example.url/manga/1" target="_blank" class="break-normal el-link el-link--default">
           <!----><span class="el-link--inner">Manga Title</span>
           <!----></a></div>
     </td>
-    <td rowspan="1" colspan="1" class="el-table_1_column_3  ">
+    <td rowspan="1" colspan="1" class="el-table_3_column_13  ">
       <div class="cell">1</div>
     </td>
-    <td rowspan="1" colspan="1" class="el-table_1_column_4  ">
+    <td rowspan="1" colspan="1" class="el-table_3_column_14  ">
       <div class="cell"><a href="example.url/manga/1/chapter/2" target="_blank" class="el-link el-link--default">
           <!----><span class="el-link--inner">2</span>
           <!----></a></div>
     </td>
-    <td rowspan="1" colspan="1" class="el-table_1_column_5  ">
+    <td rowspan="1" colspan="1" class="el-table_3_column_15  ">
       <div class="cell">10 months ago</div>
     </td>
   </tr>


### PR DESCRIPTION
This improves the **Last Chapter** and **Last Released at** handling, as suggested in #14 

Manga list will now show **No chapters** in the Last Chapter URL column if there are no chapters found. And Last released at will show up as **Unknown**.

I also introduce custom sorting, so that **Unknown** released that are shown as oldest. I still think it might be a bit annoying if you had loads, so I'd like to add a filter in the future, to hide Unknown if a user so desires.

![image](https://user-images.githubusercontent.com/4270980/67145110-5a815980-f276-11e9-9bb4-954eda9434ff.png)
