### PR TITLE
Add email confirmation

### DIFF
--- a/src/components/TheResetPassword.vue
+++ b/src/components/TheResetPassword.vue
@@ -15,7 +15,7 @@
         | Check your
         |
         strong {{ user.email }}
-        |  inbox for instructions from us on how to verify your account
+        |  inbox for instructions from us on how to reset your password
     template(v-else)
       el-form-item(prop='email')
         p.leading-normal.text-gray-600

--- a/src/router.js
+++ b/src/router.js
@@ -55,5 +55,19 @@ export default new Router({
         }
       },
     },
+    {
+      path: '/confirmation/:confirmationToken',
+      name: 'User Confirmation',
+      component: () => import(/* webpackChunkName: "user_confirmation" */ './views/UserConfirmation.vue'),
+      props: true,
+      beforeEnter: (to, from, next) => {
+        if (store.getters["user/signedIn"]) {
+          Message.info("You've already signed in");
+          next('/manga-list');
+        } else {
+          next();
+        }
+      },
+    },
   ]
 })

--- a/src/store/modules/user.js
+++ b/src/store/modules/user.js
@@ -44,27 +44,6 @@ const actions = {
         }
       });
   },
-  signUp({ _commit }, data) {
-    const loading = Loading.service({ target: '#sign-on-card' });
-
-    return plain.post('/api/v1/registrations/', { user: data })
-      .then(() => {
-        Message({
-          message: `Thank you for registering. Please email hi@kenmei.co from
-          the same email to get your account confirmed`,
-          type: 'success',
-          duration: 0,
-          showClose: true,
-        });
-      })
-      .catch((request) => {
-        Message.error({
-          dangerouslyUseHTMLString: true,
-          message: request.response.data,
-        });
-      })
-      .then(() => { loading.close(); });
-  },
   updatePassword({ commit }, { resetPasswordToken, user }) {
     const loading = Loading.service({ target: '#reset-pass-card' });
     const payload = { user, reset_password_token: resetPasswordToken };

--- a/src/store/modules/user.js
+++ b/src/store/modules/user.js
@@ -21,7 +21,7 @@ const actions = {
       .catch((request) => {
         if (request.response.data.error === 'User unconfirmed') {
           Message.info(
-            'Please email hi@kenmei.co to get your account confirmed'
+            'Please check your email inbox and confirm your account first'
           );
         } else {
           Message.error(request.response.data.error);

--- a/src/views/UserConfirmation.vue
+++ b/src/views/UserConfirmation.vue
@@ -1,0 +1,69 @@
+<template lang="pug">
+  .container.mx-auto.w-full.h-full
+    .flex.flex-col.h-full.w-full.items-center.justify-center
+      base-card.max-w-sm
+        .px-6.py-4#user-confirmation-card
+          p.text-lg.leading-normal.text-gray-600.text-center(
+            v-if="tokenValid === null"
+          )
+            | Checking token validity
+            br
+            i.el-icon-loading
+          p.leading-normal.text-gray-600.text-center(v-else)
+            | {{ this.validationError }}
+</template>
+
+<script>
+  import { mapGetters, mapMutations } from 'vuex';
+
+  import { plain } from '@/modules/axios';
+
+  export default {
+    props: {
+      confirmationToken: {
+        type: String,
+        required: true,
+      },
+    },
+    data() {
+      return {
+        tokenValid: null,
+        validationError: '',
+      };
+    },
+    computed: {
+      ...mapGetters('user', [
+        'signedIn',
+      ]),
+    },
+    mounted() {
+      this.checkTokenValidity();
+    },
+    methods: {
+      ...mapMutations('user', [
+        'setCurrentUser',
+      ]),
+      checkTokenValidity() {
+        plain.get(`/auth/confirmations/?confirmation_token=${this.confirmationToken}`)
+          .then((response) => {
+            this.setCurrentUser({ user_id: response.data.user_id });
+            localStorage.access = response.data.access;
+            this.$router.push({ name: 'manga-list' });
+          })
+          .catch((request) => {
+            const { error } = request.response.data;
+
+            this.tokenValid = false;
+
+            if (error === 'Token not found') {
+              this.validationError = error;
+            } else {
+              this.validationError = `
+                Something went wrong, try again later or contact hi@kenmei.co
+              `;
+            }
+          });
+      },
+    },
+  };
+</script>

--- a/tests/store/modules/user.spec.js
+++ b/tests/store/modules/user.spec.js
@@ -100,7 +100,7 @@ describe('user', () => {
 
         expect(commit).not.toHaveBeenCalledWith('setCurrentUser');
         expect(infoMessageSpy).toHaveBeenLastCalledWith(
-          'Please email hi@kenmei.co to get your account confirmed'
+          'Please check your email inbox and confirm your account first'
         );
       });
     });

--- a/tests/store/modules/user.spec.js
+++ b/tests/store/modules/user.spec.js
@@ -157,50 +157,6 @@ describe('user', () => {
       });
     });
 
-    describe('signUp', () => {
-      it('POSTs to registrations endpoint and show confirmation message', async () => {
-        const axiosSpy = jest.spyOn(axios, 'post');
-        const mockData = {
-          email: 'test@example.com',
-          password: 'password',
-          password_confirmation: 'password',
-        };
-
-        axiosSpy.mockResolvedValue({ status: 200 });
-
-        user.actions.signUp({ commit }, mockData);
-
-        await flushPromises();
-
-        expect(axiosSpy).toHaveBeenCalledWith(
-          '/api/v1/registrations/',
-          { user: mockData }
-        );
-      });
-
-      it('shows server-side errors if request failed', async () => {
-        const axiosSpy        = jest.spyOn(axios, 'post');
-        const errorMessageSpy = jest.spyOn(Message, 'error');
-
-        const mockData     = { email: 'test@example.com' };
-        const mockResponse = {
-          response: {
-            data: 'Missing password<br>Missing password confirmation',
-          },
-        };
-
-        axiosSpy.mockRejectedValue(mockResponse);
-
-        user.actions.signUp({ commit }, mockData);
-
-        await flushPromises();
-
-        expect(commit).not.toHaveBeenCalledWith('setCurrentUser');
-        // TODO: Check that we actually called it with server-side errors
-        expect(errorMessageSpy).toBeCalled();
-      });
-    });
-
     describe('updatePassword', () => {
       it('PUTs to passwords endpoint and logs in user on success', async () => {
         const axiosSpy = jest.spyOn(axios, 'put');

--- a/tests/views/UserConfirmation.spec.js
+++ b/tests/views/UserConfirmation.spec.js
@@ -1,0 +1,89 @@
+import { shallowMount, createLocalVue } from '@vue/test-utils';
+import Vuex from 'vuex';
+import axios from 'axios';
+import flushPromises from 'flush-promises';
+
+import UserConfirmation from '@/views/UserConfirmation.vue';
+
+import user from '@/store/modules/user';
+
+const localVue = createLocalVue();
+
+localVue.use(Vuex);
+
+describe('UserConfirmation.vue', () => {
+  let userConfirmation;
+  let store;
+
+  beforeEach(() => {
+    store = new Vuex.Store({
+      modules: {
+        user: {
+          namespaced: true,
+          state: user.state,
+          getters: user.getters,
+        },
+      },
+    });
+
+    userConfirmation = shallowMount(UserConfirmation, {
+      store,
+      localVue,
+      propsData: {
+        confirmationToken: 'token',
+      },
+    });
+  });
+
+  describe('when visiting the page', () => {
+    it('shows token is validating message if validating token', async () => {
+      expect(userConfirmation.text()).toContain('Checking token validity');
+    });
+
+    describe('when token is invalid', () => {
+      let axiosSpy;
+
+      beforeEach(() => {
+        axiosSpy = jest.spyOn(axios, 'get');
+      });
+
+      it('shows token not valid validation error', async () => {
+        axiosSpy.mockRejectedValue(
+          { response: { data: { error: 'Token not found' } } }
+        );
+
+        userConfirmation = shallowMount(UserConfirmation, {
+          store,
+          localVue,
+          propsData: {
+            confirmationToken: 'token',
+          },
+        });
+
+        await flushPromises();
+
+        expect(userConfirmation.text()).toContain('Token not found');
+      });
+
+      it('shows generic validation error', async () => {
+        const error = 'Something went wrong, try again later or contact hi@kenmei.co';
+
+        axiosSpy.mockRejectedValue(
+          { response: { data: { error: 'Unexpected' } } }
+        );
+
+        userConfirmation = shallowMount(UserConfirmation, {
+          store,
+          localVue,
+          propsData: {
+            confirmationToken: 'token',
+          },
+        });
+
+        await flushPromises();
+
+        expect(userConfirmation.text()).toContain(error);
+      });
+    });
+  });
+});


### PR DESCRIPTION
With the update on the API, users will now receive a confirmation email on registration. 
This PR updates the client-side: 
1. To have a confirmation view, which will log in users if the token is valid. 
2. To update the message shown on the registration to check inbox, instead of emailing me
3. Same copy update on the sign-in

## Email
![image](https://user-images.githubusercontent.com/4270980/67148456-b4464b80-f297-11e9-9782-5e0400ce5136.png)

## Confirmation started copy
![image](https://user-images.githubusercontent.com/4270980/67148558-8ad9ef80-f298-11e9-94c3-808247b5089f.png)
