### PR TITLE
Disable update button for no chapter series

### DIFF
--- a/src/components/TheMangaList.vue
+++ b/src/components/TheMangaList.vue
@@ -64,6 +64,7 @@
           placement="top-start"
         )
           el-button(
+            v-if="scope.row.attributes.last_chapter_available"
             ref="updateEntryButton"
             icon="el-icon-check"
             size="mini"


### PR DESCRIPTION
We don't want uses to overwrite their custom added chapters, as the button uses the latest chapter information. If there is none, entry will be overwritten with nil last read