### PR TITLE
Add loading on async entry update action

### DIFF
--- a/src/components/TheMangaList.vue
+++ b/src/components/TheMangaList.vue
@@ -88,6 +88,7 @@
             icon="el-icon-check"
             size="mini"
             @click="setLastRead(scope.row)"
+            :loading="entryUpdated === scope.row"
             circle
             v-tippy
           )
@@ -141,6 +142,7 @@
       return {
         currentPage: 1,
         sortedData: [],
+        entryUpdated: null,
       };
     },
     computed: {
@@ -166,17 +168,24 @@
         'updateEntry',
       ]),
       async setLastRead(entry) {
+        this.entryUpdated = entry;
+
         const attributes = {
           last_chapter_read: entry.attributes.last_chapter_available,
           last_chapter_read_url: entry.links.last_chapter_available_url,
         };
+
         const response = await updateMangaEntry(entry.id, attributes);
         if (response) {
-          Message.info('Updated last read chapter');
+          Message.info(
+            `Updated last read chapter to ${attributes.last_chapter_read}`
+          );
           this.updateEntry(response);
         } else {
           Message.error("Couldn't update. Try refreshing the page");
         }
+
+        this.entryUpdated = null;
       },
       applySorting({ _column, prop, order }) {
         this.sortedData = sortBy(this.tableData, prop, order);

--- a/tests/components/TheMangaList.spec.js
+++ b/tests/components/TheMangaList.spec.js
@@ -54,6 +54,20 @@ describe('TheMangaList.vue', () => {
       jest.restoreAllMocks();
     });
 
+    it('sets last chapter read button to loading', async () => {
+      updateMangaEntryMock.mockResolvedValue(false);
+
+      expect(mangaList.vm.$data.entryUpdated).toBeNull();
+
+      mangaList.find({ ref: 'updateEntryButton' }).trigger('click');
+
+      expect(mangaList.vm.$data.entryUpdated).toBe(defaultEntries[0]);
+
+      await flushPromises();
+
+      expect(mangaList.vm.$data.entryUpdated).toBeNull();
+    });
+
     it('mutates the state and shows success message', async () => {
       const infoMessageMock = jest.spyOn(Message, 'info');
       const mangaEntry = mangaEntryFactory.build({ id: 1 });
@@ -68,7 +82,9 @@ describe('TheMangaList.vue', () => {
 
       await flushPromises();
 
-      expect(infoMessageMock).toHaveBeenCalledWith('Updated last read chapter');
+      expect(infoMessageMock).toHaveBeenCalledWith(
+        'Updated last read chapter to 2'
+      );
     });
 
     it('shows error message if update failed', async () => {


### PR DESCRIPTION
This PR adds a loading indicator on the Set to Last Chapter Available button, while the request is happening. While this should be an instant request, sometimes it might have a hiccup, which would make users confused, leading to pressing the button a second time.

I also include which chapter was updated in the success message

![async-loading-entry](https://user-images.githubusercontent.com/4270980/78886175-af4ba300-7a55-11ea-8bdd-e9cd80bea02f.gif)