### PR TITLE
Add correct title sorting

### DIFF
--- a/src/components/TheMangaList.vue
+++ b/src/components/TheMangaList.vue
@@ -1,5 +1,6 @@
 <template lang="pug">
   el-table.sm_shadow-lg.sm_rounded(
+    ref="mangaListTable"
     :data="tableData"
     :default-sort = "{ prop: 'newReleases', order: 'ascending' }"
     v-loading='listsLoading'
@@ -15,7 +16,12 @@
     )
       template(slot-scope="scope")
         .new-chapter-dot(v-if="unread(scope.row)")
-    el-table-column(prop="attributes.title" label="Name" sortable)
+    el-table-column(
+      prop="attributes.title"
+      label="Title"
+      :sort-method="titleSort"
+      sortable
+    )
       template(slot-scope="scope")
         el-link.break-normal(
           :href="scope.row.links.series_url"
@@ -141,6 +147,12 @@
         } else {
           Message.error("Couldn't update. Try refreshing the page");
         }
+      },
+      titleSort(entryA, entryB) {
+        const entryATitle = entryA.attributes.title.toLowerCase();
+        const entryBTitle = entryB.attributes.title.toLowerCase();
+
+        return entryATitle.localeCompare(entryBTitle);
       },
       newReleasesSort(entryA, entryB) {
         return Number(this.unread(entryB)) - Number(this.unread(entryA));

--- a/tests/components/TheMangaList.spec.js
+++ b/tests/components/TheMangaList.spec.js
@@ -233,6 +233,34 @@ describe('TheMangaList.vue', () => {
       expect(tableRows.at(2).text()).toContain('55');
     });
 
+    it.skip(':tableData - sort titles alphabetically ignoring case', async () => {
+      const first = mangaEntryFactory.build(
+        { attributes: { title: 'a' } }
+      );
+      const second = mangaEntryFactory.build(
+        { attributes: { title: 'b' } }
+      );
+      const last = mangaEntryFactory.build(
+        { attributes: { title: 'C' } }
+      );
+      const mangaList = mount(MangaList, {
+        store,
+        localVue,
+        sync: false,
+        propsData: { tableData: [second, first, last] },
+      });
+
+      await flushPromises();
+
+      mangaList.vm.$refs.mangaListTable.sort('attributes.title', 'ascending');
+
+      const tableRows = mangaList.findAll('.el-table__row');
+
+      expect(tableRows.at(0).text()).toContain('a');
+      expect(tableRows.at(1).text()).toContain('b');
+      expect(tableRows.at(2).text()).toContain('C');
+    });
+
     it(':tableData - sanitizes manga title to convert special characters', async () => {
       mangaList.setProps({
         tableData: [


### PR DESCRIPTION
Previously, the sorting didn't correctly handle lowercase titles. This commit makes sure to lowercase all the titles, before comparing them.

This also renames the label to Title from Name, as that's how we refer to it everywhere else