### PR TITLE
Extract upload component

### DIFF
--- a/src/components/TheImporters.vue
+++ b/src/components/TheImporters.vue
@@ -1,0 +1,133 @@
+<template lang="pug">
+  el-tabs(v-model="activeTab" stretch)
+    el-tab-pane(label="Trakr.moe" name="trackrMoe")
+      el-upload(
+        ref="upload"
+        action=""
+        :http-request="processUpload"
+        :multiple="false"
+        :show-file-list="false"
+        accept="application/json"
+        drag
+        )
+        i.el-icon-upload
+        .el-upload__text
+          | Drop file here or click to upload
+        .el-upload__tip(slot="tip")
+          | You can download your Trackr.moe list
+          |
+          el-link.align-baseline.text-xs(
+            href="https://trackr.moe/user/options"
+            :underline="false"
+            target="_blank"
+          )
+            | here
+          progress-bar.mt-2(:percentage='importProgress')
+    el-tab-pane(label="MangaDex" name="mangaDex")
+      | Coming soon
+</template>
+
+<script>
+  import pLimit from 'p-limit';
+  import { mapGetters } from 'vuex';
+  import {
+    Tabs, TabPane, Input, Link, Upload, Button, Message, Loading,
+  } from 'element-ui';
+
+  import ProgressBar from '@/components/ProgressBar';
+  import { processList, sliceIntoBatches } from '@/services/importer';
+  import { addMangaEntries } from '@/services/api';
+
+  export default {
+    components: {
+      ProgressBar,
+      'el-input': Input,
+      'el-link': Link,
+      'el-upload': Upload,
+      'el-tabs': Tabs,
+      'el-tab-pane': TabPane,
+      'el-button': Button,
+    },
+    data() {
+      return {
+        activeTab: 'trackrMoe',
+        importURL: '',
+        importProgress: 0,
+      };
+    },
+    computed: {
+      ...mapGetters('lists', [
+        'entryAlreadyExists',
+      ]),
+    },
+    methods: {
+      processMangaDexList(list) {
+        let seriesImported  = 0;
+        const filteredLists = {};
+        const promiseLimit  = pLimit(1);
+        const listsToImport = processList(list);
+
+        Object.entries(listsToImport).forEach(([name, list]) => {
+          filteredLists[name] = list
+            .map(url => ({
+              seriesURL: url.full_title_url,
+              lastRead: url.title_data.current_chapter,
+            }))
+            .filter(url => !this.entryAlreadyExists(url.seriesURL));
+        });
+
+        if (Object.values(filteredLists).every(list => list.length === 0)) {
+          Message.info('Nothing new to import');
+          return;
+        }
+
+        const entriesToImport = Object.values(filteredLists).flat();
+        const URLChunks       = sliceIntoBatches(filteredLists);
+
+        const requestList = URLChunks.map(payload => promiseLimit(
+          () => addMangaEntries(payload).then(
+            (importedList) => {
+              seriesImported += importedList.data.length;
+              this.importProgress = Math.floor(
+                seriesImported / entriesToImport.length * 100
+              );
+
+              return importedList.data;
+            }
+          )
+        ));
+
+        this.importMangaInBatches(requestList);
+      },
+      async importMangaInBatches(requestList) {
+        const loading = Loading.service({ target: '.el-upload-dragger' });
+        await Promise.all(requestList)
+          .then((importedList) => {
+            const importedManga = importedList.flat();
+
+            Message.info(`Imported ${importedManga.length} series`);
+          })
+          .catch((_error) => {
+            Message.error('Something went wrong');
+          })
+          .then(() => {
+            loading.close();
+            this.$emit('importCompleted');
+          });
+      },
+      processUpload(file) {
+        // Reset import progress
+        this.importProgress = 0;
+
+        const reader = new FileReader();
+
+        reader.onload = ((theFile) => {
+          const json = JSON.parse(theFile.target.result);
+          this.processMangaDexList(json);
+        });
+
+        reader.readAsText(file.file);
+      },
+    },
+  };
+</script>

--- a/tests/components/TheImporters.spec.js
+++ b/tests/components/TheImporters.spec.js
@@ -1,0 +1,120 @@
+import { shallowMount, createLocalVue } from '@vue/test-utils';
+import Vuex from 'vuex';
+import { Message } from 'element-ui';
+import flushPromises from 'flush-promises';
+import TheImporters from '@/components/TheImporters.vue';
+import lists from '@/store/modules/lists';
+import * as api from '@/services/api';
+
+import mangaEntryFactory from '../factories/mangaEntry';
+
+const localVue = createLocalVue();
+
+localVue.use(Vuex);
+
+// To avoid missing directive Vue warnings
+localVue.directive('loading', true);
+
+describe('TheImporters.vue', () => {
+  describe('when importing MangaDex entries from Trackr.moe JSON', () => {
+    let importedList;
+    let mangaEntry;
+    let store;
+    let importers;
+
+    beforeEach(() => {
+      importedList = {
+        series: {
+          reading: {
+            manga: [{
+              full_title_url: 'example.url/manga/1',
+              title_data: {
+                current_chapter: '38201:--:v5/c34',
+              },
+              site_data: {
+                site: 'mangadex.org',
+              },
+            }],
+          },
+        },
+      };
+      mangaEntry = mangaEntryFactory.build();
+      store = new Vuex.Store({
+        modules: {
+          lists: {
+            namespaced: true,
+            state: {
+              lists: [],
+              entries: [],
+            },
+            actions: lists.actions,
+            getters: lists.getters,
+            mutations: lists.mutations,
+          },
+        },
+      });
+      importers = shallowMount(TheImporters, { store, localVue });
+    });
+
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
+    it('parses manga list from a json file', async () => {
+      const file = new File(
+        [importedList], 'list.json', { type: 'application/json' }
+      );
+      const fileReaderReadTextMock = jest.spyOn(window, 'FileReader');
+
+      fileReaderReadTextMock.mockImplementation(() => ({
+        readAsText: jest.fn(),
+      }));
+
+      importers.vm.processUpload({ file });
+
+      await flushPromises();
+
+      expect(fileReaderReadTextMock).toHaveBeenCalled();
+    });
+
+    it('adds new manga entries and updates progress percentage if successful', async () => {
+      const addMangaEntriesMock = jest.spyOn(api, 'addMangaEntries');
+
+      addMangaEntriesMock.mockResolvedValue({ data: [mangaEntry] });
+
+      importers.vm.processMangaDexList(importedList);
+
+      await flushPromises();
+
+      // TODO: Find out why this is not woring anymore
+      // expect(mangaList.vm.currentListEntries).toContain(mangaEntry);
+      expect(importers.vm.$data.importProgress).toEqual(100);
+      expect(importers.emitted('importCompleted')).toBeTruthy();
+    });
+
+    it('shows Something went wrong message if import failed', async () => {
+      const errorMessageMock    = jest.spyOn(Message, 'error');
+      const addMangaEntriesMock = jest.spyOn(api, 'addMangaEntries');
+
+      addMangaEntriesMock.mockRejectedValue();
+
+      importers.vm.processMangaDexList(importedList);
+
+      await flushPromises();
+
+      expect(errorMessageMock).toHaveBeenCalledWith('Something went wrong');
+    });
+
+    it('ignores already existing entries', async () => {
+      const infoMessageMock = jest.spyOn(Message, 'info');
+
+      store.state.lists.entries = [mangaEntry];
+
+      importers.vm.processMangaDexList(importedList);
+
+      await flushPromises();
+
+      expect(infoMessageMock).toHaveBeenCalledWith('Nothing new to import');
+    });
+  });
+});


### PR DESCRIPTION
In preparation for adding MDList importer, this PR extracts the contents of the import modal, into its own component, now separated in tabs. As a result, there is now better separation of concerns with the MangaList view. The step beyond is to extract most of the importing process into services, but I'll leave that for later

![image](https://user-images.githubusercontent.com/4270980/68480465-ced36b00-022c-11ea-8859-69f54e7d566b.png)
