### PR TITLE
Ignore urls we don't want to track

### DIFF
--- a/src/packs/main.js
+++ b/src/packs/main.js
@@ -20,6 +20,7 @@ Vue.use(VueAnalytics, {
   debug: {
     sendHitTask: process.env.NODE_ENV === 'production',
   },
+  ignoreRoutes: ['User Confirmation', 'Reset Password']
 });
 Vue.use(Rollbar, {
   accessToken: process.env.ROLLBAR_CLIENT_TOKEN,


### PR DESCRIPTION
There is no need to track user confirmation or reset password urls with Google Analytics