### PR TITLE
Improve SEO Audit

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -25,14 +25,14 @@
     <meta name='twitter:creator' content='@KenmeiApp'/>
     <meta name='twitter:image:src' content='https://www.kenmei.co/meta-image.png'/>
     <!-- Favicons and Icons links -->
-    <link rel="apple-touch-icon-precomposed" sizes="57x57" href="<%= BASE_URL %>apple-touch-icon-57x57.png" />
-    <link rel="apple-touch-icon-precomposed" sizes="114x114" href="<%= BASE_URL %>apple-touch-icon-114x114.png" />
-    <link rel="apple-touch-icon-precomposed" sizes="72x72" href="<%= BASE_URL %>apple-touch-icon-72x72.png" />
-    <link rel="apple-touch-icon-precomposed" sizes="144x144" href="<%= BASE_URL %>apple-touch-icon-144x144.png" />
-    <link rel="apple-touch-icon-precomposed" sizes="60x60" href="<%= BASE_URL %>apple-touch-icon-60x60.png" />
-    <link rel="apple-touch-icon-precomposed" sizes="120x120" href="<%= BASE_URL %>apple-touch-icon-120x120.png" />
-    <link rel="apple-touch-icon-precomposed" sizes="76x76" href="<%= BASE_URL %>apple-touch-icon-76x76.png" />
-    <link rel="apple-touch-icon-precomposed" sizes="152x152" href="<%= BASE_URL %>apple-touch-icon-152x152.png" />
+    <link rel="apple-touch-icon" sizes="57x57" href="<%= BASE_URL %>apple-touch-icon-57x57.png" />
+    <link rel="apple-touch-icon" sizes="114x114" href="<%= BASE_URL %>apple-touch-icon-114x114.png" />
+    <link rel="apple-touch-icon" sizes="72x72" href="<%= BASE_URL %>apple-touch-icon-72x72.png" />
+    <link rel="apple-touch-icon" sizes="144x144" href="<%= BASE_URL %>apple-touch-icon-144x144.png" />
+    <link rel="apple-touch-icon" sizes="60x60" href="<%= BASE_URL %>apple-touch-icon-60x60.png" />
+    <link rel="apple-touch-icon" sizes="120x120" href="<%= BASE_URL %>apple-touch-icon-120x120.png" />
+    <link rel="apple-touch-icon" sizes="76x76" href="<%= BASE_URL %>apple-touch-icon-76x76.png" />
+    <link rel="apple-touch-icon" sizes="152x152" href="<%= BASE_URL %>apple-touch-icon-152x152.png" />
     <link rel="icon" type="image/png" href="<%= BASE_URL %>favicon-196x196.png" sizes="196x196" />
     <link rel="icon" type="image/png" href="<%= BASE_URL %>favicon-96x96.png" sizes="96x96" />
     <link rel="icon" type="image/png" href="<%= BASE_URL %>favicon-32x32.png" sizes="32x32" />

--- a/public/index.html
+++ b/public/index.html
@@ -6,6 +6,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
     <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
     <meta name="application-name" content="Kenmei - manga tracker"/>
+    <meta name="Description" content="Cross-site manga tracker, that lets you follow manga series across websites.">
     <!-- Full-screen mode on home screen apps -->
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="mobile-web-app-capable" content="yes">

--- a/src/components/TheNavigationBar.vue
+++ b/src/components/TheNavigationBar.vue
@@ -6,7 +6,7 @@
     router
   )
     el-menu-item(index='/').border-none
-      img.w-32(src='@/assets/logo.svg')
+      img.w-32(src='@/assets/logo.svg' alt="logo")
     template(v-if='signedIn')
       el-submenu.avatar-menu.float-right(index='1')
         template(slot='title')

--- a/src/views/LandingPage.vue
+++ b/src/views/LandingPage.vue
@@ -2,7 +2,7 @@
   .container.mx-auto.w-full.h-full.flex.flex-col.justify-center.items-center
     base-card.max-w-lg.text-center.mx-5.md_mx-0
       .p-5
-        img.max-w-xs.w-full.inline.logo(src='@/assets/logo.svg')
+        img.max-w-xs.w-full.inline.logo(src='@/assets/logo.svg' alt="logo")
         .welcome-text.font-size-b.font-line-height-secondary
           p
             | Welcome to Kenmei, a new manga tracking website currently in

--- a/tests/views/__snapshots__/LandingPage.spec.js.snap
+++ b/tests/views/__snapshots__/LandingPage.spec.js.snap
@@ -11,6 +11,7 @@ exports[`LandingPage.vue renders the page 1`] = `
       class="p-5"
     >
       <img
+        alt="logo"
         class="max-w-xs w-full inline logo"
         src="@/assets/logo.svg"
       />


### PR DESCRIPTION
- Add update ios icon metatag as rel="apple-touch-icon-precomposed" link passes the audit, but it has been obsolete since iOS 7.
- Add description meta tag
- Add missing alt tags on images