### PR TITLE
Include last read chapter url during import

### DIFF
--- a/src/components/TheImporters.vue
+++ b/src/components/TheImporters.vue
@@ -71,6 +71,7 @@
           filteredLists[name] = list
             .map(url => ({
               seriesURL: url.full_title_url,
+              chapterURL: url.generated_current_data.url,
               lastRead: url.title_data.current_chapter,
             }))
             .filter(url => !this.entryAlreadyExists(url.seriesURL));

--- a/tests/components/TheImporters.spec.js
+++ b/tests/components/TheImporters.spec.js
@@ -28,6 +28,9 @@ describe('TheImporters.vue', () => {
           reading: {
             manga: [{
               full_title_url: 'example.url/manga/1',
+              generated_current_data: {
+                url: 'example.url/chapter/1',
+              },
               title_data: {
                 current_chapter: '38201:--:v5/c34',
               },


### PR DESCRIPTION
API will soon be able to correctly import latest read chapters from Trackr.moe. This PR updates the client to send that URL to the API