### PR TITLE
Newly released sort is ordered by released at

### DIFF
--- a/src/services/sorters.js
+++ b/src/services/sorters.js
@@ -37,7 +37,7 @@ export default function sortBy(array, sortType, order) {
     sortedData = array.sort(releasedAtSort);
     break;
   case 'newReleases':
-    sortedData = array.sort(newReleasesSort);
+    sortedData = array.sort(releasedAtSort).sort(newReleasesSort);
     break;
   case 'attributes.title':
     sortedData = array.sort(titleSort);

--- a/tests/services/sorters.spec.js
+++ b/tests/services/sorters.spec.js
@@ -66,13 +66,13 @@ describe('Sorters', () => {
       expect(sorted[2]).toBe(entry3);
     });
 
-    it('sorts by newly released', () => {
+    it('sorts by newly released, ordered by released at', () => {
       const sorted = sortBy(
         [entry2, entry1, entry3], 'newReleases', 'ascending'
       );
 
-      expect(sorted[0]).toBe(entry2);
-      expect(sorted[1]).toBe(entry1);
+      expect(sorted[0]).toBe(entry1);
+      expect(sorted[1]).toBe(entry2);
       expect(sorted[2]).toBe(entry3);
     });
   });


### PR DESCRIPTION
As a small QoL improvement, newly released series are also ordered by released at, so we always get the newest unread chapters at the top of the list

![image](https://user-images.githubusercontent.com/4270980/68974677-3703ed00-07e9-11ea-88b0-f89f6f6615bc.png)
