### PR TITLE
Don't show Mark Last Read button on no chapters

### DIFF
--- a/src/components/TheMangaList.vue
+++ b/src/components/TheMangaList.vue
@@ -161,7 +161,8 @@
           last_chapter_read_url, last_chapter_available_url,
         } = entry.links;
 
-        return last_chapter_read_url !== last_chapter_available_url;
+        return last_chapter_available_url
+          && (last_chapter_read_url !== last_chapter_available_url);
       },
       unread(entry) {
         const {


### PR DESCRIPTION
Previously, I would show the button to set last read as latest released, only if the links differed. Which would happen for when the last released chapter don't exist. This PR adds a quick check to check for last released chapter to exist, to decide whatever to show the button