### PR TITLE
Only use Rollbar in production

### DIFF
--- a/src/packs/main.js
+++ b/src/packs/main.js
@@ -22,22 +22,25 @@ Vue.use(VueAnalytics, {
   },
   ignoreRoutes: ['User Confirmation', 'Reset Password']
 });
-Vue.use(Rollbar, {
-  accessToken: process.env.ROLLBAR_CLIENT_TOKEN,
-  captureUncaught: true,
-  captureUnhandledRejections: true,
-  enabled: true,
-  environment: process.env.NODE_ENV,
-  payload: {
-    client: {
-      javascript: {
-        code_version: '1.0',
-        source_map_enabled: true,
-        guess_uncaught_frames: true,
+
+if (process.env.NODE_ENV === 'production') {
+  Vue.use(Rollbar, {
+    accessToken: process.env.ROLLBAR_CLIENT_TOKEN,
+    captureUncaught: true,
+    captureUnhandledRejections: true,
+    enabled: true,
+    environment: process.env.NODE_ENV,
+    payload: {
+      client: {
+        javascript: {
+          code_version: '1.0',
+          source_map_enabled: true,
+          guess_uncaught_frames: true,
+        },
       },
     },
-  },
-});
+  });
+}
 
 Vue.config.errorHandler = (err, _vm, _info) => { Vue.rollbar.error(err); };
 


### PR DESCRIPTION
I don't use rollbar in development, and as a result it would swallow exceptions, making it harder to debug issues during development. This adds a check for the environment, so that only production bugs are being reported to Rollbar