### PR TITLE
Add ability to bulk edit manga entries

### DIFF
--- a/src/components/TheMangaList.vue
+++ b/src/components/TheMangaList.vue
@@ -78,7 +78,7 @@
               ref="updateEntryButton"
               icon="el-icon-check"
               size="mini"
-              @click="tryEntryUpdate(scope.row)"
+              @click="setLastRead(scope.row)"
               circle
             )
     .flex.flex-row.justify-center
@@ -173,8 +173,12 @@
           && (last_chapter_read_url !== last_chapter_available_url);
       },
       /* eslint-enable camelcase */
-      async tryEntryUpdate(entry) {
-        const response = await updateMangaEntry(entry);
+      async setLastRead(entry) {
+        const attributes = {
+          last_chapter_read: entry.attributes.last_chapter_available,
+          last_chapter_read_url: entry.links.last_chapter_available_url,
+        };
+        const response = await updateMangaEntry(entry.id, attributes);
         if (response) {
           Message.info('Updated last read chapter');
           this.updateEntry(response);

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -16,13 +16,17 @@ export const addMangaEntry = (seriesURL, mangaListID) => secure
     return response.data;
   });
 
-export const updateMangaEntry = entry => secure
-  .put(`/api/v1/manga_entries/${entry.id}`, {
-    manga_entry: {
-      last_chapter_read: entry.attributes.last_chapter_available,
-      last_chapter_read_url: entry.links.last_chapter_available_url,
-    },
+export const updateMangaEntry = (id, attributes) => secure
+  .put(`/api/v1/manga_entries/${id}`, { manga_entry: attributes })
+  .then((response) => {
+    if (response.data.error) { return false; }
+
+    return response.data.data;
   })
+  .catch(_error => false);
+
+export const bulkUpdateMangaEntry = (ids, attributes) => secure
+  .put('/api/v1/manga_entries/bulk_update', { ids, manga_entry: attributes })
   .then((response) => {
     if (response.data.error) { return false; }
 

--- a/src/views/MangaList.vue
+++ b/src/views/MangaList.vue
@@ -19,43 +19,45 @@
           v-model='searchTerm'
         )
       .mx-5.mb-5.max-sm_mx-2
-        el-button.sm_shadow-md(
-          v-show="entriesSelected"
-          ref="removeSeriesButton"
-          type="danger"
-          size="medium"
-          @click="removeSeries"
-          round
-        )
-          i.el-icon-delete.mr-1
-          | Remove
-        el-button.sm_shadow-md(
-          v-show="entriesSelected"
-          ref="editMangaEntriesButton"
-          type="info"
-          size="medium"
-          @click="editDialogVisible = true"
-          round
-        )
-          i.el-icon-edit.mr-1
-          | Edit
-        el-button.sm_shadow-md.float-right(
-          ref="openAddMangaModalButton"
-          type="primary"
-          size="medium"
-          @click="dialogVisible = true"
-          round
-        )
-          i.el-icon-plus.mr-1
-          | Add Manga
-        el-button.sm_shadow-md.float-right.mr-3(
-          type="success"
-          size="medium"
-          @click="importDialogVisible = true"
-          round
-        )
-          i.el-icon-upload2.mr-1
-          | Import
+        .bulk-actions.inline-block.max-sm_mb-5.max-sm_float-right
+          el-button.sm_shadow-md(
+            v-show="entriesSelected"
+            ref="removeSeriesButton"
+            type="danger"
+            size="medium"
+            @click="removeSeries"
+            round
+          )
+            i.el-icon-delete.mr-1
+            | Remove
+          el-button.sm_shadow-md(
+            v-show="entriesSelected"
+            ref="editMangaEntriesButton"
+            type="info"
+            size="medium"
+            @click="editDialogVisible = true"
+            round
+          )
+            i.el-icon-edit.mr-1
+            | Edit
+        .actions.inline-block.float-right
+          el-button.sm_shadow-md(
+            ref="openAddMangaModalButton"
+            type="primary"
+            size="medium"
+            @click="dialogVisible = true"
+            round
+          )
+            i.el-icon-plus.mr-1
+            | Add Manga
+          el-button.sm_shadow-md(
+            type="success"
+            size="medium"
+            @click="importDialogVisible = true"
+            round
+          )
+            i.el-icon-upload2.mr-1
+            | Import
       .flex-grow.sm_mx-5.mx-0
         the-manga-list(
           :tableData='filteredEntries || currentListEntries'

--- a/tests/services/api.spec.js
+++ b/tests/services/api.spec.js
@@ -42,28 +42,85 @@ describe('API', () => {
   });
 
   describe('updateMangaEntry()', () => {
-    it('makes a request to the API and returns updated entry if found', async () => {
-      const mangaEntry = mangaEntryFactory.build();
+    let mangaEntry;
+    let attributes;
 
+    beforeEach(() => {
+      mangaEntry = mangaEntryFactory.build();
+      attributes = {
+        last_chapter_read: mangaEntry.attributes.last_chapter_available,
+        last_chapter_read_url: mangaEntry.links.last_chapter_available_url,
+      };
+    });
+
+    afterEach(() => {
+      expect(axios.put).toHaveBeenCalledWith(
+        `/api/v1/manga_entries/${mangaEntry.id}`,
+        { manga_entry: attributes }
+      );
+    });
+
+    it('makes a request to the API and returns updated entry if found', async () => {
       axios.put.mockResolvedValue({ status: 200, data: { data: mangaEntry } });
 
-      const data = await apiService.updateMangaEntry(mangaEntry);
+      const data = await apiService.updateMangaEntry(mangaEntry.id, attributes);
       expect(data).toEqual(mangaEntry);
     });
 
     it('makes a request to the API and returns false if entry not found', async () => {
-      const mangaEntry = mangaEntryFactory.build();
       axios.put.mockResolvedValue({ status: 404, data: { error: 'error' } });
 
-      const data = await apiService.updateMangaEntry(mangaEntry);
+      const data = await apiService.updateMangaEntry(mangaEntry.id, attributes);
       expect(data).toEqual(false);
     });
 
     it('makes a request to the API and returns false if API fails', async () => {
-      const mangaEntry = mangaEntryFactory.build();
       axios.put.mockRejectedValue({ response: { data: 'Things happened' } });
 
-      const response = await apiService.updateMangaEntry(mangaEntry);
+      const data = await apiService.updateMangaEntry(mangaEntry.id, attributes);
+      expect(data).toEqual(false);
+    });
+  });
+
+  describe('bulkUpdateMangaEntry()', () => {
+    let mangaEntries;
+    let ids;
+    let attributes;
+
+    beforeEach(() => {
+      mangaEntries = mangaEntryFactory.buildList(2);
+      ids = mangaEntries.map(entry => entry.id);
+      attributes = {
+        last_chapter_read: mangaEntries[0].attributes.last_chapter_available,
+        last_chapter_read_url: mangaEntries[0].links.last_chapter_available_url,
+      };
+    });
+
+    afterEach(() => {
+      expect(axios.put).toHaveBeenCalledWith(
+        '/api/v1/manga_entries/bulk_update',
+        { ids, manga_entry: attributes }
+      );
+    });
+
+    it('makes a request to the API and returns updated entries if found', async () => {
+      axios.put.mockResolvedValue({ status: 200, data: { data: mangaEntries } });
+
+      const data = await apiService.bulkUpdateMangaEntry(ids, attributes);
+      expect(data).toEqual(mangaEntries);
+    });
+
+    it('makes a request to the API and returns false if entry not found', async () => {
+      axios.put.mockResolvedValue({ status: 404, data: { error: 'error' } });
+
+      const data = await apiService.bulkUpdateMangaEntry(ids, attributes);
+      expect(data).toEqual(false);
+    });
+
+    it('makes a request to the API and returns false if API fails', async () => {
+      axios.put.mockRejectedValue({ response: { data: 'Things happened' } });
+
+      const response = await apiService.bulkUpdateMangaEntry(ids, attributes);
       expect(response).toEqual(false);
     });
   });


### PR DESCRIPTION
This PR adds ability to bulk edit manga entries. Currently, it is only possible to update the manga entry list, but in the future this will be expanded with ability to update currently read chapter, and other attributes.

![new](https://user-images.githubusercontent.com/4270980/69963230-a8d97780-1507-11ea-8e24-8b40c556cc6a.gif)
