### PR TITLE
Use bulk delete endpoint

### DIFF
--- a/src/services/api.js
+++ b/src/services/api.js
@@ -34,10 +34,10 @@ export const bulkUpdateMangaEntry = (ids, attributes) => secure
   })
   .catch(_error => false);
 
-export const deleteMangaEntry = seriesID => secure
-  .delete(`/api/v1/manga_entries/${seriesID}`)
-  .then(_response => true)
-  .catch(_request => false);
+export const bulkDeleteMangaEntries = seriesIDs => secure
+  .delete('/api/v1/manga_entries/bulk_destroy', { data: { ids: seriesIDs } })
+  .then(() => true)
+  .catch(() => false);
 
 export const addMangaEntries = urls => secure
   .post('/api/v1/manga_entries/bulk', { urls })

--- a/src/views/MangaList.vue
+++ b/src/views/MangaList.vue
@@ -129,7 +129,7 @@
   import Importers from '@/components/TheImporters';
   import TheMangaList from '@/components/TheMangaList';
   import {
-    addMangaEntry, bulkUpdateMangaEntry, deleteMangaEntry,
+    addMangaEntry, bulkUpdateMangaEntry, bulkDeleteMangaEntries,
   } from '@/services/api';
 
   export default {
@@ -224,9 +224,15 @@
         this.currentListID = this.currentListID || this.lists[0].id;
       },
       async removeSeries() {
-        await this.selectedSeriesIDs.map(id => deleteMangaEntry(id));
+        const successful = await bulkDeleteMangaEntries(this.selectedSeriesIDs);
 
-        this.removeEntries(this.selectedSeriesIDs);
+        if (successful) {
+          this.removeEntries(this.selectedSeriesIDs);
+        } else {
+          Message.error(
+            'Deletion failed. Try reloading the page before trying again'
+          );
+        }
       },
       completeImport() {
         // Request all lists again to get new lists if created

--- a/src/views/MangaList.vue
+++ b/src/views/MangaList.vue
@@ -227,6 +227,7 @@
         const successful = await bulkDeleteMangaEntries(this.selectedSeriesIDs);
 
         if (successful) {
+          Message.info(`${this.selectedSeriesIDs.length} entries deleted`);
           this.removeEntries(this.selectedSeriesIDs);
         } else {
           Message.error(

--- a/tests/services/api.spec.js
+++ b/tests/services/api.spec.js
@@ -125,28 +125,36 @@ describe('API', () => {
     });
   });
 
-  describe('deleteMangaEntry()', () => {
+  describe('bulkDeleteMangaEntries()', () => {
+    let ids;
+
+    beforeEach(() => {
+      ids = [1, 2];
+    });
+
+    afterEach(() => {
+      expect(axios.delete).toHaveBeenCalledWith(
+        '/api/v1/manga_entries/bulk_destroy',
+        { data: { ids } }
+      );
+    });
+
     it('makes a request to the API and returns true on success', async () => {
-      const axiosSpy = jest.spyOn(axios, 'delete');
+      axios.delete.mockResolvedValue();
 
-      axiosSpy.mockResolvedValue();
-
-      const data = await apiService.deleteMangaEntry(1);
-      expect(axiosSpy).toHaveBeenCalledWith('/api/v1/manga_entries/1');
+      const data = await apiService.bulkDeleteMangaEntries(ids);
       expect(data).toBeTruthy();
     });
 
-    it('makes a request to the API and returns not_found status if series not found', async () => {
-      const axiosSpy     = jest.spyOn(axios, 'delete');
+    it('makes a request to the API and returns false if request failed', async () => {
       const mockResponse = {
         response: { data: { error: 'Can only delete own entry' } },
       };
 
-      axiosSpy.mockRejectedValue(mockResponse);
+      axios.delete.mockRejectedValue(mockResponse);
 
-      const data = await apiService.deleteMangaEntry(1);
-      expect(axiosSpy).toHaveBeenCalledWith('/api/v1/manga_entries/1');
-      expect(data).not.toBeTruthy();
+      const data = await apiService.bulkDeleteMangaEntries(ids);
+      expect(data).toBeFalsy();
     });
   });
 

--- a/tests/views/MangaList.spec.js
+++ b/tests/views/MangaList.spec.js
@@ -259,6 +259,16 @@ describe('MangaList.vue', () => {
     describe('if deletion was successful', () => {
       beforeEach(() => { bulkDeleteMangaEntriesMock.mockResolvedValue(true); });
 
+      it('tells user how many entries have been deleted', async () => {
+        const infoMessageMock = jest.spyOn(Message, 'info');
+
+        mangaList.vm.removeSeries();
+
+        await flushPromises();
+
+        expect(infoMessageMock).toHaveBeenCalledWith('1 entries deleted');
+      });
+
       it('removes deleted entries', async () => {
         mangaList.vm.removeSeries();
 


### PR DESCRIPTION
This PR changes the endpoints to use a new, more optimised endpoint for bulk deletion. The API now makes sure to do a single SQL query to delete 1 or many entries, avoiding N+1 issue and improving overall perfomance, in both memory allocation and response speed

Before (just a snippet, this is actually 5x longer trace...)
```ruby
Started DELETE "/api/v1/manga_entries/7303" for ::1 at 2019-12-03 13:26:32 +0000
Processing by Api::V1::MangaEntriesController#destroy as HTML
  Parameters: {"id"=>"7303"}
  MangaEntry Load (0.4ms)  SELECT "manga_entries".* FROM "manga_entries" WHERE "manga_entries"."id" = $1 LIMIT $2  [["id", 7303], ["LIMIT", 1]]
  ↳ app/controllers/api/v1/manga_entries_controller.rb:67:in `destroy'
  MangaList Load (0.3ms)  SELECT "manga_lists".* FROM "manga_lists" WHERE "manga_lists"."id" = $1 LIMIT $2  [["id", 2], ["LIMIT", 1]]
  ↳ app/controllers/api/v1/manga_entries_controller.rb:71:in `destroy'
  User Load (0.3ms)  SELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2  [["id", 1], ["LIMIT", 1]]
  ↳ app/controllers/api/v1/manga_entries_controller.rb:71:in `destroy'
  CACHE User Load (0.0ms)  SELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2  [["id", 1], ["LIMIT", 1]]
  ↳ app/controllers/application_controller.rb:10:in `current_user'
   (0.3ms)  BEGIN
  ↳ app/controllers/api/v1/manga_entries_controller.rb:75:in `destroy'
  MangaEntry Destroy (0.9ms)  DELETE FROM "manga_entries" WHERE "manga_entries"."id" = $1  [["id", 7303]]
  ↳ app/controllers/api/v1/manga_entries_controller.rb:75:in `destroy'
   (5.0ms)  COMMIT
  ↳ app/controllers/api/v1/manga_entries_controller.rb:75:in `destroy'
Completed 200 OK in 19ms (Views: 0.1ms | ActiveRecord: 7.2ms | Allocations: 6387)

Started DELETE "/api/v1/manga_entries/7293" for ::1 at 2019-12-03 13:26:32 +0000
   (2.7ms)  BEGIN
  ↳ app/controllers/api/v1/manga_entries_controller.rb:75:in `destroy'
   (6.7ms)  COMMIT
  MangaEntry Destroy (4.9ms)  DELETE FROM "manga_entries" WHERE "manga_entries"."id" = $1  [["id", 7299]]
   (7.4ms)  COMMIT
  ↳ app/controllers/api/v1/manga_entries_controller.rb:75:in `destroy'
Completed 200 OK in 73ms (Views: 0.3ms | ActiveRecord: 21.2ms | Allocations: 24178)

  MangaEntry Destroy (4.0ms)  DELETE FROM "manga_entries" WHERE "manga_entries"."id" = $1  [["id", 7296]]
  ↳ app/controllers/api/v1/manga_entries_controller.rb:75:in `destroy'
Processing by Api::V1::MangaEntriesController#destroy as HTML
   (1.2ms)  COMMIT
  Parameters: {"id"=>"7293"}
  ↳ app/controllers/api/v1/manga_entries_controller.rb:75:in `destroy'
  ↳ app/controllers/api/v1/manga_entries_controller.rb:75:in `destroy'
Started DELETE "/api/v1/manga_entries/7294" for ::1 at 2019-12-03 13:26:32 +0000
Completed 200 OK in 70ms (Views: 0.1ms | ActiveRecord: 31.0ms | Allocations: 24642)
```

After
```ruby
  MangaEntry Destroy (19.4ms)  DELETE FROM "manga_entries" WHERE "manga_entries"."id" IN ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)  [["id", 7202], ["id", 7201], ["id", 7204], ["id", 7198], ["id", 7197], ["id", 7205], ["id", 7199], ["id", 7195], ["id", 7196], ["id", 7203], ["id", 7191], ["id", 7192], ["id", 7200], ["id", 7193], ["id", 7194]]
```

This also now shows how many entries have been deleted and properly handles if there was an error during update.

![new-delete-preview](https://user-images.githubusercontent.com/4270980/70055331-3af98280-15d1-11ea-8cd5-095c30a01f97.gif)


![delete-failed](https://user-images.githubusercontent.com/4270980/70055205-0259a900-15d1-11ea-90bd-598aa9e45d99.gif)

