### PR TITLE
Add manga entry wrong button

### DIFF
--- a/src/services/endpoints/MangaEntriesErrors.js
+++ b/src/services/endpoints/MangaEntriesErrors.js
@@ -1,0 +1,8 @@
+import { secure } from '@/modules/axios';
+
+/* eslint-disable import/prefer-default-export */
+export const postMangaEntriesErrors = entriesIDs => secure
+  .post('/api/v1/manga_entries_errors/', { ids: entriesIDs })
+  .then(() => true)
+  .catch(() => false);
+/* eslint-enable import/prefer-default-export */

--- a/src/views/MangaList.vue
+++ b/src/views/MangaList.vue
@@ -60,6 +60,7 @@
             | Import
       .flex-grow.sm_mx-5.mx-0
         the-manga-list(
+          ref='mangaList'
           :tableData='filteredEntries || currentListEntries'
           @seriesSelected="handleSelection"
         )
@@ -275,9 +276,13 @@
         this.editDialogVisible = false;
         this.newListID = null;
       },
+      clearTableSelection() {
+        this.$refs.mangaList.$refs.mangaListTable.clearSelection();
+      },
       resetSelectedAttributes() {
         this.selectedSeriesIDs = [];
         this.newListID = null;
+        this.clearTableSelection();
       },
     },
   };

--- a/src/views/MangaList.vue
+++ b/src/views/MangaList.vue
@@ -108,14 +108,21 @@
             :label="list.attributes.name"
             :value="list.id"
           )
-        span(slot="footer" class="dialog-footer")
-          el-button(@click="closeEditModal") Cancel
+        .dialog-footer.text-left(slot="footer")
           el-button(
-            ref="updateEntryButton"
-            type="primary"
-            @click="updateMangaEntries"
+            ref="reportEntryErrorButton"
+            type="danger"
+            @click="reportEntryError"
           )
-            | Update
+            | Wrong Info?
+          .float-right
+            el-button(@click="closeEditModal") Cancel
+            el-button(
+              ref="updateEntryButton"
+              type="primary"
+              @click="updateMangaEntries"
+            )
+              | Update
 </template>
 
 <script>
@@ -129,6 +136,9 @@
 
   import Importers from '@/components/TheImporters';
   import TheMangaList from '@/components/TheMangaList';
+  import {
+    postMangaEntriesErrors,
+  } from '@/services/endpoints/MangaEntriesErrors';
   import {
     addMangaEntry, bulkUpdateMangaEntry, bulkDeleteMangaEntries,
   } from '@/services/api';
@@ -233,6 +243,22 @@
         } else {
           Message.error(
             'Deletion failed. Try reloading the page before trying again'
+          );
+        }
+      },
+      async reportEntryError() {
+        const successful = await postMangaEntriesErrors(this.selectedSeriesIDs);
+
+        if (successful) {
+          this.closeEditModal();
+          this.resetSelectedAttributes();
+          Message.success(
+            'Issue reported. Entries will be updated'
+              + ' automatically shortly or investigated in detail later'
+          );
+        } else {
+          Message.error(
+            'Failed to report. Try reloading the page before trying again'
           );
         }
       },

--- a/src/views/MangaList.vue
+++ b/src/views/MangaList.vue
@@ -42,6 +42,14 @@
             | Edit
         .actions.inline-block.float-right
           el-button.sm_shadow-md(
+            type="success"
+            size="medium"
+            @click="importDialogVisible = true"
+            round
+          )
+            i.el-icon-upload2.mr-1
+            | Import
+          el-button.sm_shadow-md(
             ref="openAddMangaModalButton"
             type="primary"
             size="medium"
@@ -50,14 +58,6 @@
           )
             i.el-icon-plus.mr-1
             | Add Manga
-          el-button.sm_shadow-md(
-            type="success"
-            size="medium"
-            @click="importDialogVisible = true"
-            round
-          )
-            i.el-icon-upload2.mr-1
-            | Import
       .flex-grow.sm_mx-5.mx-0
         the-manga-list(
           ref='mangaList'

--- a/tests/services/endpoints/MangaEntriesErrors.spec.js
+++ b/tests/services/endpoints/MangaEntriesErrors.spec.js
@@ -1,0 +1,25 @@
+import axios from 'axios';
+import * as resource from '@/services/endpoints/MangaEntriesErrors';
+
+describe('MangaEntriesErrors', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('postMangaEntriesErrors()', () => {
+    it('makes a request to the resource and returns true', async () => {
+      axios.post.mockResolvedValue({ status: 200 });
+
+      const successful = await resource.postMangaEntriesErrors({ ids: ['1'] });
+
+      expect(successful).toBeTruthy();
+    });
+
+    it('makes a request to the resource and returns false if failed', async () => {
+      axios.post.mockRejectedValue({ status: 500 });
+
+      const successful = await resource.postMangaEntriesErrors({ ids: [] });
+      expect(successful).toBeFalsy();
+    });
+  });
+});

--- a/tests/views/MangaList.spec.js
+++ b/tests/views/MangaList.spec.js
@@ -145,7 +145,15 @@ describe('MangaList.vue', () => {
           },
         },
       });
-      mangaList = shallowMount(MangaList, { store, localVue });
+      mangaList = shallowMount(MangaList, {
+        store,
+        localVue,
+        methods: {
+          clearTableSelection() {
+            return true;
+          },
+        },
+      });
       mangaList.setData({
         selectedSeriesIDs: ['1'],
         currentListID: '1',
@@ -247,7 +255,15 @@ describe('MangaList.vue', () => {
           },
         },
       });
-      mangaList = shallowMount(MangaList, { store, localVue });
+      mangaList = shallowMount(MangaList, {
+        store,
+        localVue,
+        methods: {
+          clearTableSelection() {
+            return true;
+          },
+        },
+      });
       mangaList.setData({ selectedSeriesIDs: ['1'], currentListID: '1' });
     });
 

--- a/tests/views/MangaList.spec.js
+++ b/tests/views/MangaList.spec.js
@@ -19,6 +19,10 @@ localVue.use(Vuex);
 localVue.directive('loading', true);
 
 describe('MangaList.vue', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
   describe('when adding new MangaDex entry', () => {
     let store;
     let mangaList;
@@ -42,10 +46,6 @@ describe('MangaList.vue', () => {
 
       mangaList.setData({ mangaURL: 'example.url/manga/1' });
       mangaList.find({ ref: 'openAddMangaModalButton' }).trigger('click');
-    });
-
-    afterEach(() => {
-      jest.restoreAllMocks();
     });
 
     it('adds new Manga entry on successful API lookup', async () => {
@@ -167,7 +167,6 @@ describe('MangaList.vue', () => {
       expect(updateMangaEntriesMock).toHaveBeenCalledWith(
         ['1'], { manga_list_id: '2' }
       );
-      jest.restoreAllMocks();
     });
 
     describe('if update was successful', () => {
@@ -269,7 +268,6 @@ describe('MangaList.vue', () => {
 
     afterEach(() => {
       expect(bulkDeleteMangaEntriesMock).toHaveBeenCalledWith(['1']);
-      jest.restoreAllMocks();
     });
 
     describe('if deletion was successful', () => {


### PR DESCRIPTION
This PR adds a new button `Wrong Info?`, which will send a report to me with the information of the entry that has wrong information. I have an automatic process that will attempt to fix the issue. 
- If it succeeds, users will see correct dated fairly quickly. 
- If It fails, I would get notified and I will then proceed to investigate the issue manually, to see if there is a bug or something alike.

I also accidently flipped the ordering of buttons in #113, so I also fix that in the final commit

![report-entries](https://user-images.githubusercontent.com/4270980/70167851-81c5a600-16bf-11ea-8d3f-2a1ba7bdcf03.gif)
