### PR TITLE
Update the copy and style of the newsletter form

### DIFF
--- a/src/views/LandingPage.vue
+++ b/src/views/LandingPage.vue
@@ -6,26 +6,26 @@
         .welcome-text.font-size-b.font-line-height-secondary
           p
             | Welcome to Kenmei, a new manga tracking website currently in
-            | development.
+            | alpha.
           p
             | Inspired by
             |
             el-link.inline.align-baseline(
-              href="https://www.trackr.moe" :underline="false"
+              href="https://www.trackr.moe" type="primary" :underline="false"
             )
               | trackr.moe
             |, the best manga tracking website,
             |
             el-link.inline.align-baseline(
               href="https://blog.codeanimu.net/posts/2019/07/trackr-moe-the-future/"
+              type="primary"
               :underline="false"
             )
               | that is now slated to be closed
             |, Kenmei is here to replace it
             | and provide even more features, for all manga fans out there!
           p
-            | If you would like to get notified, when registrations open, please
-            | leave your email below.
+            | To get development updates, please leave your email below.
         .email-form
           form(
             action='https://tinyletter.com/kenmei'

--- a/tests/views/__snapshots__/LandingPage.spec.js.snap
+++ b/tests/views/__snapshots__/LandingPage.spec.js.snap
@@ -20,7 +20,7 @@ exports[`LandingPage.vue renders the page 1`] = `
       >
         <p>
           Welcome to Kenmei, a new manga tracking website currently in
-development.
+alpha.
         </p>
         <p>
           Inspired by
@@ -28,7 +28,7 @@ development.
           <el-link-stub
             class="inline align-baseline"
             href="https://www.trackr.moe"
-            type="default"
+            type="primary"
           >
             trackr.moe
           </el-link-stub>
@@ -37,7 +37,7 @@ development.
           <el-link-stub
             class="inline align-baseline"
             href="https://blog.codeanimu.net/posts/2019/07/trackr-moe-the-future/"
-            type="default"
+            type="primary"
           >
             that is now slated to be closed
           </el-link-stub>
@@ -45,8 +45,7 @@ development.
 and provide even more features, for all manga fans out there!
         </p>
         <p>
-          If you would like to get notified, when registrations open, please
-leave your email below.
+          To get development updates, please leave your email below.
         </p>
       </div>
       <div


### PR DESCRIPTION
Registration is now open, but the copy was stating otherwise. This PR updates that + changes the link style to be more obvious.

![image](https://user-images.githubusercontent.com/4270980/71309651-6d451580-2402-11ea-8463-b59a53e1d7d2.png)
