### PR TITLE
Fix last chapter discovery with the new MangaDex host

### DIFF
--- a/src/components/TheMangaList.vue
+++ b/src/components/TheMangaList.vue
@@ -100,7 +100,7 @@
   import he from 'he';
   import relativeTime from 'dayjs/plugin/relativeTime';
 
-  import { updateMangaEntry } from '@/services/api';
+  import { updateMangaEntry, extractSeriesID } from '@/services/api';
   import sortBy from '@/services/sorters';
 
   dayjs.extend(relativeTime);
@@ -162,7 +162,7 @@
         } = entry.links;
 
         return last_chapter_available_url
-          && (last_chapter_read_url !== last_chapter_available_url);
+          && (extractSeriesID(last_chapter_read_url) !== extractSeriesID(last_chapter_available_url));
       },
       unread(entry) {
         const {
@@ -170,7 +170,7 @@
         } = entry.links;
 
         return last_chapter_read_url
-          && (last_chapter_read_url !== last_chapter_available_url);
+          && (extractSeriesID(last_chapter_read_url) !== extractSeriesID(last_chapter_available_url));
       },
       /* eslint-enable camelcase */
       async setLastRead(entry) {

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -1,7 +1,7 @@
 import { secure } from '@/modules/axios';
 
 // This can extract both the series and chapter, we want to make use of that
-export const extractSeriesID = url => url.match(/(?!\/)\d+/g)[0];
+export const extractSeriesID = url => (url !== null ? url.match(/(?!\/)\d+/g)[0] : url);
 
 export const addMangaEntry = (seriesURL, mangaListID) => secure
   .post('/api/v1/manga_entries/', {

--- a/src/services/sorters.js
+++ b/src/services/sorters.js
@@ -1,3 +1,5 @@
+import { extractSeriesID } from '@/services/api';
+
 /* eslint-disable camelcase */
 const unread = (entry) => {
   const {
@@ -5,7 +7,7 @@ const unread = (entry) => {
   } = entry.links;
 
   return last_chapter_read_url
-    && (last_chapter_read_url !== last_chapter_available_url);
+    && (extractSeriesID(last_chapter_read_url) !== extractSeriesID(last_chapter_available_url));
 };
 
 const titleSort = (entryA, entryB) => {

--- a/tests/factories/mangaEntry.js
+++ b/tests/factories/mangaEntry.js
@@ -11,8 +11,8 @@ export default new Factory()
   })
   .attr('links', {
     series_url: 'example.url/manga/1',
-    last_chapter_read_url: 'example.url/manga/1/chapter/1',
-    last_chapter_available_url: 'example.url/manga/1/chapter/2',
+    last_chapter_read_url: 'example.url/chapter/1',
+    last_chapter_available_url: 'example.url/chapter/2',
   })
   .attr('relationships', {
     manga_list: {

--- a/tests/services/api.spec.js
+++ b/tests/services/api.spec.js
@@ -9,13 +9,17 @@ describe('API', () => {
   });
 
   describe('extractSeriesID()', () => {
-    it('extracts an ID from a MangaDex series or chapter URL', () => {
+    it('returns MangaDex ID from a MangaDex series or chapter URL', () => {
       expect(
         apiService.extractSeriesID('https://mangadex.org/chapter/671525')
       ).toEqual('671525');
       expect(
         apiService.extractSeriesID('https://mangadex.org/title/65')
       ).toEqual('65');
+    });
+
+    it('returns empty string if URL is null', () => {
+      expect(apiService.extractSeriesID(null)).toEqual(null);
     });
   });
 


### PR DESCRIPTION
I temporary will make use of ID extractor, to compare by the ID, instead of the full url, when sorting by new and showing which series have new chapters out.

This will be updated, when I delegate the source id lookup to the API