### PR TITLE
Update extractSeriesID to handle null match

### DIFF
--- a/src/services/api.js
+++ b/src/services/api.js
@@ -1,7 +1,12 @@
 import { secure } from '@/modules/axios';
 
 // This can extract both the series and chapter, we want to make use of that
-export const extractSeriesID = url => (url !== null ? url.match(/(?!\/)\d+/g)[0] : url);
+export const extractSeriesID = (url) => {
+  if (url == null) { return url; }
+
+  const match = url.match(/(?!\/)\d+/g);
+  return match !== null ? match[0] : null;
+};
 
 export const addMangaEntry = (seriesURL, mangaListID) => secure
   .post('/api/v1/manga_entries/', {

--- a/tests/services/api.spec.js
+++ b/tests/services/api.spec.js
@@ -18,8 +18,12 @@ describe('API', () => {
       ).toEqual('65');
     });
 
-    it('returns empty string if URL is null', () => {
+    it('returns null if URL is null', () => {
       expect(apiService.extractSeriesID(null)).toEqual(null);
+    });
+
+    it("returns null if can't find ID", () => {
+      expect(apiService.extractSeriesID('test')).toEqual(null);
     });
   });
 


### PR DESCRIPTION
When matching the ID of the manga, I was expecting to always match if the url was present. But that is not the case, and unlike Ruby, if you don't find a regex match, you would be left with a `null`, on which I was then calling `[0]` which would fail.

This PR makes sure I check if the match was null as well, avoiding that issue altogether