### PR TITLE
Move Trackr.moe import to background

### DIFF
--- a/src/components/TheImporters.vue
+++ b/src/components/TheImporters.vue
@@ -1,30 +1,34 @@
 <template lang="pug">
   el-tabs(v-model="activeTab" stretch)
     el-tab-pane(label="Trakr.moe" name="trackrMoe")
-      el-upload(
-        ref="upload"
-        action=""
-        :http-request="processUpload"
-        :multiple="false"
-        :show-file-list="false"
-        accept="application/json"
-        drag
-        )
-        i.el-icon-upload
-        .el-upload__text
-          | Drop file here or click to upload
-        .el-upload__tip(slot="tip")
-          | You can download your Trackr.moe list
-          |
-          el-link.align-baseline.text-xs(
-            href="https://trackr.moe/user/options"
-            :underline="false"
-            target="_blank"
+      template(v-if="trackrMoeimportInitiated")
+        p.leading-normal.text-gray-600.text-center.break-normal
+          | Your Trackr.moe import has started. You will receive an email
+          | when the series have been imported.
+      template(v-else)
+        el-upload(
+          ref="upload"
+          action=""
+          :http-request="processUpload"
+          :multiple="false"
+          :show-file-list="false"
+          accept="application/json"
+          drag
           )
-            | here
-          progress-bar.mt-2(:percentage='importProgress')
+          i.el-icon-upload
+          .el-upload__text
+            | Drop file here or click to upload
+          .el-upload__tip(slot="tip")
+            | You can download your Trackr.moe list
+            |
+            el-link.align-baseline.text-xs(
+              href="https://trackr.moe/user/options"
+              :underline="false"
+              target="_blank"
+            )
+              | here
     el-tab-pane(label="MangaDex" name="mangaDex")
-      template(v-if="importInitiated")
+      template(v-if="mangaDexImportInitiated")
         p.leading-normal.text-gray-600.text-center.break-normal
           | Your MangaDex MDList import has started. You will receive an email
           | when the series have been imported.
@@ -47,7 +51,6 @@
 </template>
 
 <script>
-  import pLimit from 'p-limit';
   import { mapGetters } from 'vuex';
   import {
     Tabs, TabPane, Input, Link, Upload, Button, Message, Loading,
@@ -56,8 +59,8 @@
   import { secure } from '@/modules/axios';
 
   import ProgressBar from '@/components/ProgressBar';
-  import { processList, sliceIntoBatches } from '@/services/importer';
-  import { addMangaEntries } from '@/services/api';
+  import { processList } from '@/services/importer';
+  import { postTrackrMoe } from '@/services/endpoints/importers';
 
   export default {
     components: {
@@ -74,7 +77,8 @@
         activeTab: 'trackrMoe',
         importURL: '',
         importProgress: 0,
-        importInitiated: false,
+        mangaDexImportInitiated: false,
+        trackrMoeimportInitiated: false,
       };
     },
     computed: {
@@ -90,7 +94,7 @@
         const loading = Loading.service({ target: '.el-dialog' });
         secure.post('/api/v1/importers/mangadex', { url: this.importURL })
           .then(() => {
-            this.importInitiated = true;
+            this.mangaDexImportInitiated = true;
           })
           .catch((_error) => {
             Message.error(
@@ -101,10 +105,8 @@
             loading.close();
           });
       },
-      processMangaDexList(list) {
-        let seriesImported  = 0;
+      async processMangaDexList(list) {
         const filteredLists = {};
-        const promiseLimit  = pLimit(1);
         const listsToImport = processList(list);
 
         Object.entries(listsToImport).forEach(([name, list]) => {
@@ -113,48 +115,21 @@
               seriesURL: url.full_title_url,
               chapterURL: url.generated_current_data.url,
               lastRead: url.title_data.current_chapter,
-            }))
-            .filter(url => !this.entryAlreadyExists(url.seriesURL));
+            }));
         });
 
-        if (Object.values(filteredLists).every(list => list.length === 0)) {
-          Message.info('Nothing new to import');
-          return;
+        const loading    = Loading.service({ target: '.el-upload-dragger' });
+        const successful = await postTrackrMoe(filteredLists);
+
+        if (successful) {
+          this.trackrMoeimportInitiated = true;
+        } else {
+          Message.error(
+            'Something went wrong, try again later or contact hi@kenmei.co'
+          );
         }
 
-        const entriesToImport = Object.values(filteredLists).flat();
-        const URLChunks       = sliceIntoBatches(filteredLists);
-
-        const requestList = URLChunks.map(payload => promiseLimit(
-          () => addMangaEntries(payload).then(
-            (importedList) => {
-              seriesImported += importedList.data.length;
-              this.importProgress = Math.floor(
-                seriesImported / entriesToImport.length * 100
-              );
-
-              return importedList.data;
-            }
-          )
-        ));
-
-        this.importMangaInBatches(requestList);
-      },
-      async importMangaInBatches(requestList) {
-        const loading = Loading.service({ target: '.el-upload-dragger' });
-        await Promise.all(requestList)
-          .then((importedList) => {
-            const importedManga = importedList.flat();
-
-            Message.info(`Imported ${importedManga.length} series`);
-          })
-          .catch((_error) => {
-            Message.error('Something went wrong');
-          })
-          .then(() => {
-            loading.close();
-            this.$emit('importCompleted');
-          });
+        loading.close();
       },
       processUpload(file) {
         // Reset import progress

--- a/src/services/endpoints/importers.js
+++ b/src/services/endpoints/importers.js
@@ -1,0 +1,8 @@
+import { secure } from '@/modules/axios';
+
+/* eslint-disable import/prefer-default-export */
+export const postTrackrMoe = filteredLists => secure
+  .post('/api/v1/importers/trackr_moe', { lists: filteredLists })
+  .then(() => true)
+  .catch(() => false);
+/* eslint-enable import/prefer-default-export */

--- a/src/services/importer.js
+++ b/src/services/importer.js
@@ -1,3 +1,4 @@
+/* eslint-disable import/prefer-default-export */
 export const processList = (list) => {
   const lists = {};
   const filterMD = manga => manga.filter(
@@ -10,17 +11,4 @@ export const processList = (list) => {
 
   return lists;
 };
-
-export const sliceIntoBatches = (lists) => {
-  const batchSize = 20;
-  const URLChunks = [];
-
-  Object.entries(lists).forEach(([name, list]) => {
-    for (let i = 0; i < list.length; i += batchSize) {
-      const formatURLs = list.slice(i, i + batchSize);
-      URLChunks.push({ [name]: formatURLs });
-    }
-  });
-
-  return URLChunks;
-};
+/* eslint-enable import/prefer-default-export */

--- a/tests/services/endpoints/importers.spec.js
+++ b/tests/services/endpoints/importers.spec.js
@@ -1,0 +1,25 @@
+import axios from 'axios';
+import * as resource from '@/services/endpoints/importers';
+
+describe('importers', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('postTrackrMoe()', () => {
+    it('makes a request to the resource and returns true', async () => {
+      axios.post.mockResolvedValue({ status: 200 });
+
+      const successful = await resource.postTrackrMoe({ lists: {} });
+
+      expect(successful).toBeTruthy();
+    });
+
+    it('makes a request to the resource and returns false if failed', async () => {
+      axios.post.mockRejectedValue({ status: 500 });
+
+      const successful = await resource.postTrackrMoe({ lists: {} });
+      expect(successful).toBeFalsy();
+    });
+  });
+});

--- a/tests/services/importer.spec.js
+++ b/tests/services/importer.spec.js
@@ -13,14 +13,4 @@ describe('Importer', () => {
       // TODO: Test only MangaDex is being returned
     });
   });
-
-  describe('sliceIntoBatches', () => {
-    it('slices lists into chunks of 20', () => {
-      const response = Importer.sliceIntoBatches(filteredList);
-
-      expect(response).toHaveLength(2);
-      expect(response[0].reading).toHaveLength(20);
-      expect(response[1].reading).toHaveLength(2);
-    });
-  });
 });


### PR DESCRIPTION
Instead of doing the import in real-time, it will now happen in the background. It should still happen as fast, but it's now easier to manage errors, retry import and manage duplicate entries. 