### PR TITLE
Remove entryAlreadyExists

### DIFF
--- a/src/components/TheImporters.vue
+++ b/src/components/TheImporters.vue
@@ -51,7 +51,6 @@
 </template>
 
 <script>
-  import { mapGetters } from 'vuex';
   import {
     Tabs, TabPane, Input, Link, Upload, Button, Message, Loading,
   } from 'element-ui';
@@ -82,9 +81,6 @@
       };
     },
     computed: {
-      ...mapGetters('lists', [
-        'entryAlreadyExists',
-      ]),
       validUrl() {
         return this.importURL.match(/(mangadex.(cc|org)\/list[/])\d+$/) !== null;
       },

--- a/src/store/modules/lists.js
+++ b/src/store/modules/lists.js
@@ -1,8 +1,6 @@
 import { Message } from 'element-ui';
 import { secure } from '@/modules/axios';
 
-import { extractSeriesID } from '@/services/api';
-
 const state = {
   lists: [],
   entries: [],
@@ -12,9 +10,6 @@ const state = {
 const getters = {
   getEntriesByListId: state => listID => state.entries.filter(
     entry => entry.relationships.manga_list.data.id === listID
-  ),
-  entryAlreadyExists: state => mangaURL => state.entries.some(
-    manga => extractSeriesID(manga.links.series_url) === extractSeriesID(mangaURL)
   ),
 };
 

--- a/src/views/MangaList.vue
+++ b/src/views/MangaList.vue
@@ -190,7 +190,6 @@
       ]),
       ...mapGetters('lists', [
         'getEntriesByListId',
-        'entryAlreadyExists',
       ]),
       entriesSelected() {
         return this.selectedSeriesIDs.length > 0;
@@ -287,12 +286,6 @@
         this.retrieveLists();
       },
       mangaDexSearch() {
-        if (this.entryAlreadyExists(this.mangaURL)) {
-          Message.info('Manga already added');
-          this.dialogVisible = false;
-          return;
-        }
-
         const loading = Loading.service({ target: '.el-dialog' });
         addMangaEntry(this.mangaURL, this.currentListID)
           .then((newMangaEntry) => {
@@ -305,6 +298,9 @@
               loading.close();
             } else if (error.response.status === 404) {
               Message.info('Manga was not found');
+              loading.close();
+            } else if (error.response.status === 406) {
+              Message.info('Manga already added');
               loading.close();
             } else {
               Message.error('Something went wrong');

--- a/tests/store/modules/lists.spec.js
+++ b/tests/store/modules/lists.spec.js
@@ -28,23 +28,6 @@ describe('lists', () => {
         expect(getEntriesByListId(listID)).toEqual([expectedReturn]);
       });
     });
-
-    describe('entryAlreadyExists', () => {
-      it('returns entries based on a list id', () => {
-        const state = {
-          entries: mangaEntryFactory.buildList(
-            1,
-            { links: { series_url: 'example.url/manga/12' } }
-          ),
-        };
-
-        const entryAlreadyExists = lists.getters.entryAlreadyExists(state);
-
-        expect(entryAlreadyExists('example.url/manga/12')).toBeTruthy();
-        expect(entryAlreadyExists('example.url/manga/1')).not.toBeTruthy();
-        expect(entryAlreadyExists('example.url/manga/2')).not.toBeTruthy();
-      });
-    });
   });
 
   describe('mutations', () => {

--- a/tests/views/MangaList.spec.js
+++ b/tests/views/MangaList.spec.js
@@ -80,16 +80,19 @@ describe('MangaList.vue', () => {
       expect(infoMessageMock).toHaveBeenCalledWith('Manga was not found');
     });
 
-    it('shows Manga already added if it has already been added', () => {
+    it('shows Manga already added if it has already been added', async () => {
+      const addMangaEntryMock = jest.spyOn(api, 'addMangaEntry');
       const infoMessageMock = jest.spyOn(Message, 'info');
-
-      store.state.lists.entries = [mangaEntryFactory.build()];
 
       mangaList = shallowMount(MangaList, { store, localVue });
 
       mangaList.setData({ mangaURL: 'example.url/manga/1' });
 
+      addMangaEntryMock.mockRejectedValue({ response: { status: 406 } });
+
       mangaList.vm.mangaDexSearch();
+
+      await flushPromises();
 
       expect(infoMessageMock).toHaveBeenCalledWith('Manga already added');
     });


### PR DESCRIPTION
Now that we are going to have new sources, we can't have client hardcoded for MangaDex. Hence I removed extractID method, and instead delegate to the API for checks on whatever the entry already exists or not