### PR TITLE
Extract modals from MangaList component

### DIFF
--- a/src/components/manga_entries/AddMangaEntry.vue
+++ b/src/components/manga_entries/AddMangaEntry.vue
@@ -1,0 +1,78 @@
+<template lang="pug">
+  #add-manga-entry
+    label.font-size-b.primary-text Manga URL
+    el-input.mt-3(
+      v-model="mangaURL"
+      placeholder="https://mangadex.org/title/7139/"
+      prefix-icon="el-icon-link"
+    )
+    .mt-8.-mb-2.text-right
+      el-button(@click="$emit('dialogClosed')") Cancel
+      el-button(
+        ref="addMangaButton"
+        type="primary"
+        @click="mangaDexSearch"
+        :disabled="mangaURL.length === 0"
+      )
+        | Add
+</template>
+
+<script>
+  import { mapMutations } from 'vuex';
+  import {
+    Message, Button, Input, Loading,
+  } from 'element-ui';
+  import { addMangaEntry } from '@/services/api';
+
+  export default {
+    name: 'AddMangaEntry',
+    components: {
+      'el-button': Button,
+      'el-input': Input,
+    },
+    props: {
+      currentListID: {
+        type: String,
+        required: true,
+      },
+    },
+    data() {
+      return {
+        mangaURL: '',
+      };
+    },
+    methods: {
+      ...mapMutations('lists', [
+        'addEntry',
+      ]),
+      mangaDexSearch() {
+        const loading = Loading.service({ target: '.el-dialog' });
+        addMangaEntry(this.mangaURL, this.currentListID)
+          .then((newMangaEntry) => {
+            this.addEntry(newMangaEntry.data);
+            this.closeModal(loading);
+          })
+          .catch((error) => {
+            if (error.response.status === 400) {
+              Message.error('URL is incorrect');
+              loading.close();
+            } else if (error.response.status === 404) {
+              Message.info('Manga was not found');
+              loading.close();
+            } else if (error.response.status === 406) {
+              Message.info('Manga already added');
+              loading.close();
+            } else {
+              Message.error('Something went wrong');
+              this.closeModal(loading);
+            }
+          });
+      },
+      closeModal(loading) {
+        this.$emit('dialogClosed');
+        loading.close();
+        this.mangaURL = '';
+      },
+    },
+  };
+</script>

--- a/src/components/manga_entries/EditMangaEntries.vue
+++ b/src/components/manga_entries/EditMangaEntries.vue
@@ -1,0 +1,104 @@
+<template lang="pug">
+  #edit-manga-entries
+    el-select.rounded.w-full(
+      v-model="newListID"
+      placeholder="Select new list"
+    )
+      el-option(
+        v-for="list in lists"
+        :key="list.id"
+        :label="list.attributes.name"
+        :value="list.id"
+      )
+    .mt-8.-mb-2
+      el-button(
+        ref="reportEntryErrorButton"
+        type="danger"
+        @click="reportEntryError"
+      )
+        | Wrong Info?
+      .float-right
+        el-button(@click="closeEditModal('cancelEdit')") Cancel
+        el-button(
+          ref="updateEntryButton"
+          type="primary"
+          @click="updateMangaEntries"
+        )
+          | Update
+</template>
+
+<script>
+  import { mapState, mapMutations } from 'vuex';
+  import {
+    Message, Loading, Button, Select, Option,
+  } from 'element-ui';
+  import {
+    postMangaEntriesErrors,
+  } from '@/services/endpoints/MangaEntriesErrors';
+  import { bulkUpdateMangaEntry } from '@/services/api';
+
+  export default {
+    name: 'EditMangaEntries',
+    components: {
+      'el-button': Button,
+      'el-select': Select,
+      'el-option': Option,
+    },
+    props: {
+      selectedSeriesIDs: {
+        type: Array,
+        required: true,
+      },
+    },
+    data() {
+      return {
+        newListID: null,
+      };
+    },
+    computed: {
+      ...mapState('lists', [
+        'lists',
+      ]),
+    },
+    methods: {
+      ...mapMutations('lists', [
+        'updateEntry',
+      ]),
+      async updateMangaEntries() {
+        const loading = Loading.service({ target: '.edit-manga-entry-dialog' });
+        const response = await bulkUpdateMangaEntry(
+          this.selectedSeriesIDs, { manga_list_id: this.newListID }
+        );
+
+        loading.close();
+
+        if (response) {
+          Message.info(`${this.selectedSeriesIDs.length} entries updated`);
+          response.map(e => this.updateEntry(e));
+          this.closeEditModal('editComplete');
+        } else {
+          Message.error("Couldn't update. Try refreshing the page");
+        }
+      },
+      async reportEntryError() {
+        const successful = await postMangaEntriesErrors(this.selectedSeriesIDs);
+
+        if (successful) {
+          this.closeEditModal('editComplete');
+          Message.success(
+            'Issue reported. Entries will be updated'
+              + ' automatically shortly or investigated in detail later'
+          );
+        } else {
+          Message.error(
+            'Failed to report. Try reloading the page before trying again'
+          );
+        }
+      },
+      closeEditModal(emitEvent) {
+        this.$emit(emitEvent);
+        this.newListID = null;
+      },
+    },
+  };
+</script>

--- a/tests/components/manga_entries/AddMangaEntry.spec.js
+++ b/tests/components/manga_entries/AddMangaEntry.spec.js
@@ -1,0 +1,117 @@
+import { shallowMount, createLocalVue } from '@vue/test-utils';
+import Vuex from 'vuex';
+import { Message } from 'element-ui';
+import flushPromises from 'flush-promises';
+import AddMangaEntry from '@/components/manga_entries/AddMangaEntry.vue';
+import lists from '@/store/modules/lists';
+import * as api from '@/services/api';
+
+import mangaEntryFactory from '../../factories/mangaEntry';
+import mangaListFactory from '../../factories/mangaList';
+
+const localVue = createLocalVue();
+
+localVue.use(Vuex);
+
+describe('AddMangaEntry.vue', () => {
+  describe('when adding new MangaDex entry', () => {
+    let store;
+    let addMangaEntry;
+
+    const mangaList = mangaListFactory.build();
+
+    beforeEach(() => {
+      store = new Vuex.Store({
+        modules: {
+          lists: {
+            namespaced: true,
+            state: {
+              lists: [mangaList],
+              entries: [],
+            },
+            mutations: lists.mutations,
+          },
+        },
+      });
+      addMangaEntry = shallowMount(AddMangaEntry, {
+        store,
+        localVue,
+        data() {
+          return {
+            mangaURL: 'example.url/manga/1',
+          };
+        },
+        propsData: {
+          currentListID: '1',
+        },
+      });
+    });
+
+    it('adds new Manga entry on successful API lookup', async () => {
+      const addMangaEntryMock = jest.spyOn(api, 'addMangaEntry');
+      const mangaEntry        = mangaEntryFactory.build();
+
+      addMangaEntryMock.mockResolvedValue({ data: mangaEntry });
+
+      expect(store.state.lists.entries).toEqual([]);
+
+      addMangaEntry.vm.mangaDexSearch();
+
+      await flushPromises();
+
+      expect(store.state.lists.entries).toContain(mangaEntry);
+      expect(addMangaEntry.emitted('dialogClosed')).toBeTruthy();
+    });
+
+    it('shows Manga not found message if API returns nothing', async () => {
+      const infoMessageMock   = jest.spyOn(Message, 'info');
+      const addMangaEntryMock = jest.spyOn(api, 'addMangaEntry');
+
+      addMangaEntryMock.mockRejectedValue({ response: { status: 404 } });
+
+      addMangaEntry.vm.mangaDexSearch();
+
+      await flushPromises();
+      expect(infoMessageMock).toHaveBeenCalledWith('Manga was not found');
+    });
+
+    it('shows Manga already added if it has already been added', async () => {
+      const addMangaEntryMock = jest.spyOn(api, 'addMangaEntry');
+      const infoMessageMock = jest.spyOn(Message, 'info');
+
+      addMangaEntryMock.mockRejectedValue({ response: { status: 406 } });
+
+      addMangaEntry.vm.mangaDexSearch();
+
+      await flushPromises();
+
+      expect(infoMessageMock).toHaveBeenCalledWith('Manga already added');
+    });
+
+    it('shows URL is incorrect message if response is 400', async () => {
+      const infoMessageMock   = jest.spyOn(Message, 'error');
+      const addMangaEntryMock = jest.spyOn(api, 'addMangaEntry');
+
+      addMangaEntryMock.mockRejectedValue({ response: { status: 400 } });
+
+      addMangaEntry.vm.mangaDexSearch();
+
+      await flushPromises();
+      expect(infoMessageMock).toHaveBeenCalledWith('URL is incorrect');
+    });
+
+    it('shows error message on unsuccessful API lookup', async () => {
+      const errorMessageMock  = jest.spyOn(Message, 'error');
+      const addMangaEntryMock = jest.spyOn(api, 'addMangaEntry');
+
+      addMangaEntryMock.mockRejectedValue({ response: { status: 500 } });
+
+      addMangaEntry.vm.mangaDexSearch();
+
+      await flushPromises();
+
+      expect(errorMessageMock).toHaveBeenCalledWith('Something went wrong');
+      expect(addMangaEntry.emitted('dialogClosed')).toBeTruthy();
+    });
+  });
+});

--- a/tests/components/manga_entries/EditMangaEntries.spec.js
+++ b/tests/components/manga_entries/EditMangaEntries.spec.js
@@ -1,0 +1,169 @@
+import { shallowMount, createLocalVue } from '@vue/test-utils';
+import Vuex from 'vuex';
+import { Message } from 'element-ui';
+import flushPromises from 'flush-promises';
+import EditMangaEntries from '@/components/manga_entries/EditMangaEntries.vue';
+import lists from '@/store/modules/lists';
+import * as api from '@/services/api';
+import * as mangaEntriesErrors from '@/services/endpoints/MangaEntriesErrors';
+
+import mangaEntryFactory from '../../factories/mangaEntry';
+import mangaListFactory from '../../factories/mangaList';
+
+const localVue = createLocalVue();
+
+localVue.use(Vuex);
+
+describe('EditMangaEntries.vue', () => {
+  let store;
+  let editMangaEntries;
+  let mangaEntry;
+
+  beforeEach(() => {
+    mangaEntry = mangaEntryFactory.build({ id: 1 });
+
+    store = new Vuex.Store({
+      modules: {
+        lists: {
+          namespaced: true,
+          state: {
+            lists: [
+              mangaListFactory.build({ id: '1' }),
+              mangaListFactory.build({ id: '2' }),
+            ],
+            entries: [mangaEntry],
+          },
+          mutations: lists.mutations,
+        },
+      },
+    });
+    editMangaEntries = shallowMount(EditMangaEntries, {
+      store,
+      localVue,
+      data() {
+        return {
+          newListID: '2',
+        };
+      },
+      propsData: {
+        selectedSeriesIDs: ['1'],
+      },
+    });
+  });
+  describe('when updating manga entries', () => {
+    let updateMangaEntriesMock;
+    let updatedMangaEntry;
+
+    beforeEach(() => {
+      updateMangaEntriesMock = jest.spyOn(api, 'bulkUpdateMangaEntry');
+      updatedMangaEntry = mangaEntryFactory.build(
+        { relationships: { manga_list: { data: { id: '2' } } } }
+      );
+    });
+
+    afterEach(() => {
+      expect(updateMangaEntriesMock).toHaveBeenCalledWith(
+        ['1'], { manga_list_id: '2' }
+      );
+    });
+
+    describe('if update was successful', () => {
+      beforeEach(() => {
+        updateMangaEntriesMock.mockResolvedValue([updatedMangaEntry]);
+      });
+
+      it('emits editComplete and sets newListID to null', async () => {
+        editMangaEntries.vm.updateMangaEntries();
+
+        await flushPromises();
+
+        expect(editMangaEntries.vm.$data.newListID).toEqual(null);
+        expect(editMangaEntries.emitted('editComplete')).toBeTruthy();
+      });
+
+      it('tells user how many entries have been updated', async () => {
+        const infoMessageMock = jest.spyOn(Message, 'info');
+
+        editMangaEntries.vm.updateMangaEntries();
+
+        await flushPromises();
+
+        expect(infoMessageMock).toHaveBeenCalledWith('1 entries updated');
+      });
+
+      it("changes manga entry's manga list", async () => {
+        editMangaEntries.vm.updateMangaEntries();
+
+        await flushPromises();
+
+        expect(store.state.lists.entries).not.toContain(mangaEntry);
+        expect(store.state.lists.entries).toContain(updatedMangaEntry);
+      });
+    });
+
+    describe('if update was unsuccessful', () => {
+      it("shows couldn't update message and keeps entry the same", async () => {
+        const errorMessageMock = jest.spyOn(Message, 'error');
+
+        updateMangaEntriesMock.mockResolvedValue(false);
+
+        editMangaEntries.vm.updateMangaEntries();
+
+        await flushPromises();
+
+        expect(store.state.lists.entries).toContain(mangaEntry);
+        expect(store.state.lists.entries).not.toContain(updatedMangaEntry);
+        expect(errorMessageMock).toHaveBeenCalledWith(
+          "Couldn't update. Try refreshing the page"
+        );
+      });
+    });
+  });
+  describe('when reporting manga entries', () => {
+    let postMangaEntriesErrorsMock;
+
+    beforeEach(() => {
+      postMangaEntriesErrorsMock = jest.spyOn(
+        mangaEntriesErrors, 'postMangaEntriesErrors'
+      );
+    });
+
+    afterEach(() => {
+      expect(postMangaEntriesErrorsMock).toHaveBeenCalledWith(['1']);
+    });
+
+    describe('if report was successful', () => {
+      it('shows successful message', async () => {
+        const infoMessageMock = jest.spyOn(Message, 'success');
+
+        postMangaEntriesErrorsMock.mockResolvedValue(true);
+
+        editMangaEntries.vm.reportEntryError();
+
+        await flushPromises();
+
+        expect(editMangaEntries.emitted('editComplete')).toBeTruthy();
+        expect(infoMessageMock).toHaveBeenCalledWith(
+          'Issue reported. Entries will be updated'
+            + ' automatically shortly or investigated in detail later'
+        );
+      });
+    });
+
+    describe('if report was unsuccessful', () => {
+      it('shows failure message', async () => {
+        const errorMessageMock = jest.spyOn(Message, 'error');
+
+        postMangaEntriesErrorsMock.mockResolvedValue(false);
+
+        editMangaEntries.vm.reportEntryError();
+
+        await flushPromises();
+
+        expect(errorMessageMock).toHaveBeenCalledWith(
+          'Failed to report. Try reloading the page before trying again'
+        );
+      });
+    });
+  });
+});

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -16,3 +16,13 @@ globalComponentFiles.forEach((fileName) => {
 
   Vue.component(componentName, componentConfig.default || componentConfig);
 });
+
+// ===
+// Configure Vue
+// ===
+
+// Don't warn about not using the production build of Vue, as
+// we care more about the quality of errors than performance
+// for tests. Same for the Vue devtools
+Vue.config.productionTip = false;
+Vue.config.devtools = false;


### PR DESCRIPTION
Before adding nested modal for Wrong Entry? button, it was a good opportunity to refactor MangaList view. This PR extracts 2 of the modals, for adding and editing manga entries