### PR TITLE
Add basic Trackr.moe file validation

### DIFF
--- a/src/components/TheImporters.vue
+++ b/src/components/TheImporters.vue
@@ -131,7 +131,19 @@
 
         reader.onload = ((theFile) => {
           const json = JSON.parse(theFile.target.result);
-          this.processMangaDexList(json);
+
+          if (json.series) {
+            this.processMangaDexList(json);
+          } else if (json.reading) {
+            Message.error(
+              `You are trying to import partial list. Please use export from
+              Trakr.moe settings page.`
+            );
+          } else {
+            Message.error(
+              'File is incorrect. Make sure you are uploading Trackr.moe export'
+            );
+          }
         });
 
         reader.readAsText(file.file);

--- a/src/components/TheImporters.vue
+++ b/src/components/TheImporters.vue
@@ -75,7 +75,6 @@
       return {
         activeTab: 'trackrMoe',
         importURL: '',
-        importProgress: 0,
         mangaDexImportInitiated: false,
         trackrMoeimportInitiated: false,
       };
@@ -128,9 +127,6 @@
         loading.close();
       },
       processUpload(file) {
-        // Reset import progress
-        this.importProgress = 0;
-
         const reader = new FileReader();
 
         reader.onload = ((theFile) => {

--- a/tests/components/TheImporters.spec.js
+++ b/tests/components/TheImporters.spec.js
@@ -60,48 +60,61 @@ describe('TheImporters.vue', () => {
       jest.restoreAllMocks();
     });
 
-    it('parses manga list from a json file', async () => {
-      const file = new File(
-        [importedList], 'list.json', { type: 'application/json' }
-      );
-      const fileReaderReadTextMock = jest.spyOn(window, 'FileReader');
+    describe('when file is valid', () => {
+      it('parses manga list', async () => {
+        const file = new File(
+          [importedList], 'list.json', { type: 'application/json' }
+        );
+        const fileReaderReadTextMock = jest.spyOn(window, 'FileReader');
 
-      fileReaderReadTextMock.mockImplementation(() => ({
-        readAsText: jest.fn(),
-      }));
+        fileReaderReadTextMock.mockImplementation(() => ({
+          readAsText: jest.fn(),
+        }));
 
-      importers.vm.processUpload({ file });
+        importers.vm.processUpload({ file });
 
-      await flushPromises();
+        await flushPromises();
 
-      expect(fileReaderReadTextMock).toHaveBeenCalled();
+        expect(fileReaderReadTextMock).toHaveBeenCalled();
+      });
+
+      it('shows success message', async () => {
+        const postTrackrMoeMock = jest.spyOn(
+          importersEndpoint, 'postTrackrMoe'
+        );
+
+        postTrackrMoeMock.mockResolvedValue(true);
+
+        importers.vm.processMangaDexList(importedList);
+
+        await flushPromises();
+
+        expect(importers.text()).toContain(
+          'Your Trackr.moe import has started'
+        );
+      });
+
+      it('shows Something went wrong message if import failed', async () => {
+        const errorMessageMock  = jest.spyOn(Message, 'error');
+        const postTrackrMoeMock = jest.spyOn(
+          importersEndpoint, 'postTrackrMoe'
+        );
+
+        postTrackrMoeMock.mockResolvedValue(false);
+
+        importers.vm.processMangaDexList(importedList);
+
+        await flushPromises();
+
+        expect(errorMessageMock).toHaveBeenCalledWith(
+          'Something went wrong, try again later or contact hi@kenmei.co'
+        );
+      });
     });
 
-    it('shows success message', async () => {
-      const postTrackrMoeMock = jest.spyOn(importersEndpoint, 'postTrackrMoe');
-
-      postTrackrMoeMock.mockResolvedValue(true);
-
-      importers.vm.processMangaDexList(importedList);
-
-      await flushPromises();
-
-      expect(importers.text()).toContain('Your Trackr.moe import has started');
-    });
-
-    it('shows Something went wrong message if import failed', async () => {
-      const errorMessageMock  = jest.spyOn(Message, 'error');
-      const postTrackrMoeMock = jest.spyOn(importersEndpoint, 'postTrackrMoe');
-
-      postTrackrMoeMock.mockResolvedValue(false);
-
-      importers.vm.processMangaDexList(importedList);
-
-      await flushPromises();
-
-      expect(errorMessageMock).toHaveBeenCalledWith(
-        'Something went wrong, try again later or contact hi@kenmei.co'
-      );
+    describe('when file is invalid', () => {
+      it.todo('raises an File is incorrect error if not trackr.moe file');
+      it.todo('raises a Partial list error if trackr.moe list is incomplete');
     });
   });
 

--- a/tests/components/TheImporters.spec.js
+++ b/tests/components/TheImporters.spec.js
@@ -5,10 +5,7 @@ import axios from 'axios';
 import flushPromises from 'flush-promises';
 import TheImporters from '@/components/TheImporters.vue';
 import lists from '@/store/modules/lists';
-import * as api from '@/services/api';
 import * as importersEndpoint from '@/services/endpoints/importers';
-
-import mangaEntryFactory from '../factories/mangaEntry';
 
 const localVue = createLocalVue();
 


### PR DESCRIPTION
I will now raise errors if file being uploaded is not an expected trackr.moe upload. Previously I would just get uncaught errors, without any indication on the UI what went wrong. 

I currently have to add todo tests, as I am still unable to get `onload` test to work