### PR TITLE
Check for chapter numbers only

### DIFF
--- a/src/components/TheMangaList.vue
+++ b/src/components/TheMangaList.vue
@@ -74,7 +74,7 @@
             placement="top-start"
           )
             el-button(
-              v-if="lastChapterNotSet(scope.row)"
+              v-if="unread(scope.row)"
               ref="updateEntryButton"
               icon="el-icon-check"
               size="mini"
@@ -100,8 +100,8 @@
   import he from 'he';
   import relativeTime from 'dayjs/plugin/relativeTime';
 
-  import { updateMangaEntry, extractSeriesID } from '@/services/api';
-  import sortBy from '@/services/sorters';
+  import { updateMangaEntry } from '@/services/api';
+  import { unread, sortBy } from '@/services/sorters';
 
   dayjs.extend(relativeTime);
 
@@ -152,27 +152,10 @@
       },
     },
     methods: {
+      unread,
       ...mapMutations('lists', [
         'updateEntry',
       ]),
-      /* eslint-disable camelcase */
-      lastChapterNotSet(entry) {
-        const {
-          last_chapter_read_url, last_chapter_available_url,
-        } = entry.links;
-
-        return last_chapter_available_url
-          && (extractSeriesID(last_chapter_read_url) !== extractSeriesID(last_chapter_available_url));
-      },
-      unread(entry) {
-        const {
-          last_chapter_read_url, last_chapter_available_url,
-        } = entry.links;
-
-        return last_chapter_read_url
-          && (extractSeriesID(last_chapter_read_url) !== extractSeriesID(last_chapter_available_url));
-      },
-      /* eslint-enable camelcase */
       async setLastRead(entry) {
         const attributes = {
           last_chapter_read: entry.attributes.last_chapter_available,

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -1,13 +1,5 @@
 import { secure } from '@/modules/axios';
 
-// This can extract both the series and chapter, we want to make use of that
-export const extractSeriesID = (url) => {
-  if (url == null) { return url; }
-
-  const match = url.match(/(?!\/)\d+/g);
-  return match !== null ? match[0] : null;
-};
-
 export const addMangaEntry = (seriesURL, mangaListID) => secure
   .post('/api/v1/manga_entries/', {
     manga_entry: {

--- a/src/services/sorters.js
+++ b/src/services/sorters.js
@@ -1,13 +1,9 @@
-import { extractSeriesID } from '@/services/api';
-
 /* eslint-disable camelcase */
-const unread = (entry) => {
-  const {
-    last_chapter_read_url, last_chapter_available_url,
-  } = entry.links;
+export const unread = (entry) => {
+  const { last_chapter_read, last_chapter_available } = entry.attributes;
 
-  return last_chapter_read_url
-    && (extractSeriesID(last_chapter_read_url) !== extractSeriesID(last_chapter_available_url));
+  return (parseFloat(last_chapter_available) || 0)
+    > (parseFloat(last_chapter_read) || 0);
 };
 
 const titleSort = (entryA, entryB) => {
@@ -31,7 +27,7 @@ const releasedAtSort = (a, b) => {
     || +(aReleasedAt < bReleasedAt);
 };
 
-export default function sortBy(array, sortType, order) {
+export function sortBy(array, sortType, order) {
   let sortedData = [];
 
   switch (sortType) {

--- a/tests/services/api.spec.js
+++ b/tests/services/api.spec.js
@@ -8,25 +8,6 @@ describe('API', () => {
     jest.restoreAllMocks();
   });
 
-  describe('extractSeriesID()', () => {
-    it('returns MangaDex ID from a MangaDex series or chapter URL', () => {
-      expect(
-        apiService.extractSeriesID('https://mangadex.org/chapter/671525')
-      ).toEqual('671525');
-      expect(
-        apiService.extractSeriesID('https://mangadex.org/title/65')
-      ).toEqual('65');
-    });
-
-    it('returns null if URL is null', () => {
-      expect(apiService.extractSeriesID(null)).toEqual(null);
-    });
-
-    it("returns null if can't find ID", () => {
-      expect(apiService.extractSeriesID('test')).toEqual(null);
-    });
-  });
-
   describe('addMangaEntry()', () => {
     it('makes a request to the API and returns manga if found', async () => {
       const mangaURL = 'example.url/123';

--- a/tests/services/sorters.spec.js
+++ b/tests/services/sorters.spec.js
@@ -1,4 +1,4 @@
-import sortBy from '@/services/sorters';
+import { unread, sortBy } from '@/services/sorters';
 
 import mangaEntryFactory from '../factories/mangaEntry';
 
@@ -12,11 +12,9 @@ describe('Sorters', () => {
       {
         attributes: {
           title: 'a',
+          last_chapter_read: '1',
+          last_chapter_available: '2',
           last_released_at: '2019-01-10T00:00:00.000Z',
-        },
-        links: {
-          last_chapter_read_url: 'example.url/manga/1/chapter/1',
-          last_chapter_available_url: 'example.url/manga/1/chapter/2',
         },
       }
     );
@@ -24,11 +22,9 @@ describe('Sorters', () => {
       {
         attributes: {
           title: 'b',
+          last_chapter_read: '3',
+          last_chapter_available: '4',
           last_released_at: '2019-01-01T00:00:00.000Z',
-        },
-        links: {
-          last_chapter_read_url: 'example.url/manga/1/chapter/3',
-          last_chapter_available_url: 'example.url/manga/1/chapter/4',
         },
       }
     );
@@ -36,15 +32,72 @@ describe('Sorters', () => {
       {
         attributes: {
           title: 'C',
+          last_chapter_read: '5',
+          last_chapter_available: '5',
           last_released_at: null,
-        },
-        links: {
-          last_chapter_read_url: 'example.url/manga/1/chapter/5',
-          last_chapter_available_url: 'example.url/manga/1/chapter/5',
         },
       }
     );
   });
+  describe('unread', () => {
+    describe('when last chapter availiable is bigger than last read', () => {
+      it('returns true', () => {
+        const entry = mangaEntryFactory.build(
+          {
+            attributes: {
+              last_chapter_read: '4',
+              last_chapter_available: '5',
+            },
+          }
+        );
+
+        expect(unread(entry)).toBeTruthy();
+      });
+    });
+    describe('when last read null and last released chapter availiable', () => {
+      it('returns true', () => {
+        const entry = mangaEntryFactory.build(
+          {
+            attributes: {
+              last_chapter_read: null,
+              last_chapter_available: '5',
+            },
+          }
+        );
+
+        expect(unread(entry)).toBeTruthy();
+      });
+    });
+    describe('when comparing a chapter as a title with last available', () => {
+      it('returns true', () => {
+        const entry = mangaEntryFactory.build(
+          {
+            attributes: {
+              last_chapter_read: 'Oneshot',
+              last_chapter_available: '5',
+            },
+          }
+        );
+
+        expect(unread(entry)).toBeTruthy();
+      });
+    });
+    describe('when last available is null', () => {
+      it('returns false', () => {
+        const entry = mangaEntryFactory.build(
+          {
+            attributes: {
+              last_chapter_read: '2',
+              last_chapter_available: null,
+            },
+          }
+        );
+
+        expect(unread(entry)).toBeFalsy();
+      });
+    });
+  });
+
   describe('sortBy', () => {
     it('sorts by title', () => {
       const sorted = sortBy(


### PR DESCRIPTION
I've previously was checking if URL existed because Trackr imported chapters didn't have them. But in reality, we always should have a URL, hence we want to check for those. And if one is not present, it means the person didn't read any chapters, hence it's unread.

This change will also treat titles chapters (which are oneshots or unknown chapters usually) as 0. We want to start separating title from the chapter number in the future, to make sure there are no false positives when all chapters have titles, but no chapter numbers