### PR TITLE
Use manga entries index

### DIFF
--- a/src/store/modules/lists.js
+++ b/src/store/modules/lists.js
@@ -15,12 +15,18 @@ const getters = {
 
 const actions = {
   getLists({ commit }) {
-    commit('setListsLoading', true);
-
     return secure.get('/api/v1/manga_lists/')
       .then((response) => {
         commit('setLists', response.data.data);
-        commit('setEntries', response.data.included);
+      })
+      .catch((request) => { Message.error(request.response.data.error); });
+  },
+  getEntries({ commit }) {
+    commit('setListsLoading', true);
+
+    return secure.get('/api/v1/manga_entries/')
+      .then((response) => {
+        commit('setEntries', response.data.data);
       })
       .catch((request) => { Message.error(request.response.data.error); })
       .then(() => { commit('setListsLoading', false); });

--- a/src/views/MangaList.vue
+++ b/src/views/MangaList.vue
@@ -181,10 +181,12 @@
     },
     mounted() {
       this.retrieveLists();
+      this.retrieveEntries();
     },
     methods: {
       ...mapActions('lists', [
         'getLists',
+        'getEntries',
       ]),
       ...mapMutations('lists', [
         'removeEntries',
@@ -196,6 +198,9 @@
       async retrieveLists() {
         await this.getLists();
         this.currentListID = this.currentListID || this.lists[0].id;
+      },
+      async retrieveEntries() {
+        await this.getEntries();
       },
       async removeSeries() {
         const successful = await bulkDeleteMangaEntries(this.selectedSeriesIDs);

--- a/tests/store/modules/lists.spec.js
+++ b/tests/store/modules/lists.spec.js
@@ -143,9 +143,6 @@ describe('lists', () => {
 
         expect(axiosSpy).toHaveBeenCalledWith('/api/v1/manga_lists/');
         expect(commit).toHaveBeenCalledWith('setLists', initLists);
-        expect(commit).toHaveBeenCalledWith('setEntries', entries);
-        expect(commit).toHaveBeenCalledWith('setListsLoading', true);
-        expect(commit).toHaveBeenLastCalledWith('setListsLoading', false);
       });
 
       it('shows error message if request has failed', async () => {
@@ -166,6 +163,44 @@ describe('lists', () => {
           mockResponse.response.data.error
         );
         expect(commit).not.toHaveBeenCalledWith('setLists', mockResponse);
+      });
+    });
+
+    describe('getEntries', () => {
+      it('retrieves manga entries from the api', async () => {
+        const axiosSpy = jest.spyOn(axios, 'get');
+        const entries  = mangaEntryFactory.buildList(1);
+
+        axiosSpy.mockResolvedValue({ status: 200, data: { data: entries } });
+
+        lists.actions.getEntries({ commit });
+
+        await flushPromises();
+
+        expect(axiosSpy).toHaveBeenCalledWith('/api/v1/manga_entries/');
+        expect(commit).toHaveBeenCalledWith('setEntries', entries);
+        expect(commit).toHaveBeenCalledWith('setListsLoading', true);
+        expect(commit).toHaveBeenLastCalledWith('setListsLoading', false);
+      });
+
+      it('shows error message if request has failed', async () => {
+        const axiosSpy        = jest.spyOn(axios, 'get');
+        const errorMessageSpy = jest.spyOn(Message, 'error');
+        const mockResponse    = {
+          response: { data: { error: 'Entries not found' } },
+        };
+
+        axiosSpy.mockRejectedValue(mockResponse);
+
+        lists.actions.getEntries({ commit });
+
+        await flushPromises();
+
+        expect(axiosSpy).toHaveBeenCalledWith('/api/v1/manga_entries/');
+        expect(errorMessageSpy).toHaveBeenLastCalledWith(
+          mockResponse.response.data.error
+        );
+        expect(commit).not.toHaveBeenCalledWith('setEntries', mockResponse);
       });
     });
   });


### PR DESCRIPTION
This PR matches the updated back-end API changes, which makes a change to a more semantic manga entries retrieval. Instead of sending them back with lists, instead, I will be making a separate request to the correct endpoint.

Apart from semantic reasons, this will allow me to filter entries (to return only `preferred` entries for multi-source retrieval), which is not possible when using Fast JSON API serialiser includes method