### PR TITLE
Add per manga entry edit

### DIFF
--- a/src/components/TheMangaList.vue
+++ b/src/components/TheMangaList.vue
@@ -66,8 +66,15 @@
             | {{ scope.row.attributes.last_released_at | timeAgo }}
           template(v-else)
             | Unknown
-      el-table-column(width="50" class-name="actions")
+      el-table-column(width="100" class-name="actions")
         template(slot-scope="scope")
+          el-button(
+            ref="editEntryButton"
+            icon="el-icon-edit-outline"
+            size="mini"
+            @click="editMangaEntry(scope.row)"
+            circle
+          )
           el-tooltip(
             effect="dark"
             content="Set last read to the latest chapter"
@@ -178,6 +185,9 @@
         const ids = val.map(entry => entry.id);
         this.$emit('seriesSelected', ids);
       },
+      editMangaEntry(entry) {
+        this.$emit('editEntry', entry.id);
+      },
     },
   };
 </script>
@@ -195,6 +205,7 @@
   .actions > .cell {
     opacity: 0;
     transition: 0.2s ease-in-out;
+    @apply float-right;
     height: 28px; // matches the button height
   }
   tr:hover .actions > .cell {

--- a/src/components/TheMangaList.vue
+++ b/src/components/TheMangaList.vue
@@ -72,6 +72,7 @@
             effect="dark"
             content="Set last read to the latest chapter"
             placement="top-start"
+            :enterable="false"
           )
             el-button(
               v-if="unread(scope.row)"
@@ -192,7 +193,12 @@
     @apply rounded-r;
   }
   .actions > .cell {
+    opacity: 0;
+    transition: 0.2s ease-in-out;
     height: 28px; // matches the button height
+  }
+  tr:hover .actions > .cell {
+    opacity: 1;
   }
   .new-chapter-dot {
     background-color: #409EFF;

--- a/src/components/manga_entries/EditMangaEntries.vue
+++ b/src/components/manga_entries/EditMangaEntries.vue
@@ -45,7 +45,7 @@
       'el-option': Option,
     },
     props: {
-      selectedSeriesIDs: {
+      selectedEntriesIDs: {
         type: Array,
         required: true,
       },
@@ -67,13 +67,13 @@
       async updateMangaEntries() {
         const loading = Loading.service({ target: '.edit-manga-entry-dialog' });
         const response = await bulkUpdateMangaEntry(
-          this.selectedSeriesIDs, { manga_list_id: this.newListID }
+          this.selectedEntriesIDs, { manga_list_id: this.newListID }
         );
 
         loading.close();
 
         if (response) {
-          Message.info(`${this.selectedSeriesIDs.length} entries updated`);
+          Message.info(`${this.selectedEntriesIDs.length} entries updated`);
           response.map(e => this.updateEntry(e));
           this.closeEditModal('editComplete');
         } else {
@@ -81,7 +81,7 @@
         }
       },
       async reportEntryError() {
-        const successful = await postMangaEntriesErrors(this.selectedSeriesIDs);
+        const successful = await postMangaEntriesErrors(this.selectedEntriesIDs);
 
         if (successful) {
           this.closeEditModal('editComplete');

--- a/src/views/MangaList.vue
+++ b/src/views/MangaList.vue
@@ -73,6 +73,7 @@
           ref='mangaList'
           :tableData='filteredEntries || currentListEntries'
           @seriesSelected="handleSelection"
+          @editEntry='showEditEntryDialog'
         )
       el-dialog(
         title="Import Manga List"
@@ -228,6 +229,10 @@
       resetSelectedAttributes() {
         this.selectedEntriesIDs = [];
         this.clearTableSelection();
+      },
+      showEditEntryDialog(entryID) {
+        this.selectedEntriesIDs = [entryID];
+        this.editDialogVisible = true;
       },
     },
   };

--- a/src/views/MangaList.vue
+++ b/src/views/MangaList.vue
@@ -93,7 +93,8 @@
           @dialogClosed='dialogVisible = false'
         )
       el-dialog(
-        title="Edit Manga Entry"
+        ref='editMangaEntryDialog'
+        :title="editMangaEntriesDialogTitle"
         custom-class="custom-dialog edit-manga-entry-dialog"
         width="400px"
         :visible.sync="editDialogVisible"
@@ -158,6 +159,11 @@
       ...mapGetters('lists', [
         'getEntriesByListId',
       ]),
+      editMangaEntriesDialogTitle() {
+        return this.selectedEntriesIDs.length > 1
+          ? 'Edit Manga Entries'
+          : 'Edit Manga Entry';
+      },
       currentListEntries() {
         return this.getEntriesByListId(this.currentListID);
       },

--- a/src/views/MangaList.vue
+++ b/src/views/MangaList.vue
@@ -98,7 +98,7 @@
         :visible.sync="editDialogVisible"
       )
         edit-manga-entries(
-          :selectedSeriesIDs='selectedSeriesIDs'
+          :selectedEntriesIDs='selectedEntriesIDs'
           @cancelEdit='editDialogVisible = false'
           @editComplete='resetEditEntries'
         )
@@ -135,7 +135,7 @@
     },
     data() {
       return {
-        selectedSeriesIDs: [],
+        selectedEntriesIDs: [],
         currentListID: null,
         searchTerm: '',
         dialogVisible: false,
@@ -192,8 +192,8 @@
         'removeEntries',
         'setListsLoading',
       ]),
-      handleSelection(selectedSeriesIDs) {
-        this.selectedSeriesIDs = selectedSeriesIDs;
+      handleSelection(selectedEntriesIDs) {
+        this.selectedEntriesIDs = selectedEntriesIDs;
       },
       async retrieveLists() {
         await this.getLists();
@@ -203,11 +203,11 @@
         await this.getEntries();
       },
       async removeSeries() {
-        const successful = await bulkDeleteMangaEntries(this.selectedSeriesIDs);
+        const successful = await bulkDeleteMangaEntries(this.selectedEntriesIDs);
 
         if (successful) {
-          Message.info(`${this.selectedSeriesIDs.length} entries deleted`);
-          this.removeEntries(this.selectedSeriesIDs);
+          Message.info(`${this.selectedEntriesIDs.length} entries deleted`);
+          this.removeEntries(this.selectedEntriesIDs);
         } else {
           Message.error(
             'Deletion failed. Try reloading the page before trying again'
@@ -227,7 +227,7 @@
         this.$refs.mangaList.$refs.mangaListTable.clearSelection();
       },
       resetSelectedAttributes() {
-        this.selectedSeriesIDs = [];
+        this.selectedEntriesIDs = [];
         this.clearTableSelection();
       },
     },

--- a/src/views/MangaList.vue
+++ b/src/views/MangaList.vue
@@ -136,6 +136,7 @@
     data() {
       return {
         selectedEntriesIDs: [],
+        entriesSelected: false,
         currentListID: null,
         searchTerm: '',
         dialogVisible: false,
@@ -156,9 +157,6 @@
       ...mapGetters('lists', [
         'getEntriesByListId',
       ]),
-      entriesSelected() {
-        return this.selectedSeriesIDs.length > 0;
-      },
       currentListEntries() {
         return this.getEntriesByListId(this.currentListID);
       },
@@ -193,6 +191,7 @@
         'setListsLoading',
       ]),
       handleSelection(selectedEntriesIDs) {
+        this.entriesSelected = selectedEntriesIDs.length > 0;
         this.selectedEntriesIDs = selectedEntriesIDs;
       },
       async retrieveLists() {

--- a/tests/components/TheMangaList.spec.js
+++ b/tests/components/TheMangaList.spec.js
@@ -95,12 +95,26 @@ describe('TheMangaList.vue', () => {
   });
 
   describe('@events', () => {
-    it.skip('@handleSelectionChange - when selecting rows, emits seriesSelected', async () => {
-      await flushPromises();
+    const entry1 = mangaEntryFactory.build({ id: '1' });
+    const entry2 = mangaEntryFactory.build({ id: '2' });
 
-      mangaList.find('.el-checkbox').trigger('click');
+    beforeEach(() => {
+      mangaList.setData({ sortedData: [entry1, entry2] });
+    });
 
-      expect(mangaList.emitted('seriesSelected')).toBeTruthy();
+    it('@handleSelectionChange - when selecting rows, emits seriesSelected', async () => {
+      mangaList.findAll('.el-checkbox').trigger('click');
+
+      expect(mangaList.emitted('seriesSelected')[1][0]).toEqual(
+        [entry1.id, entry2.id]
+      );
+    });
+
+    it('@editEntry - when editing an entry, emits editEntry', async () => {
+      mangaList.find({ ref: 'editEntryButton' }).trigger('click');
+
+      expect(mangaList.emitted('editEntry')).toBeTruthy();
+      expect(mangaList.emitted('editEntry')[0]).toEqual([entry2.id]);
     });
   });
 

--- a/tests/components/manga_entries/EditMangaEntries.spec.js
+++ b/tests/components/manga_entries/EditMangaEntries.spec.js
@@ -46,7 +46,7 @@ describe('EditMangaEntries.vue', () => {
         };
       },
       propsData: {
-        selectedSeriesIDs: ['1'],
+        selectedEntriesIDs: ['1'],
       },
     });
   });

--- a/tests/views/MangaList.spec.js
+++ b/tests/views/MangaList.spec.js
@@ -115,6 +115,12 @@ describe('MangaList.vue', () => {
         expect(mangaList.vm.$data.editDialogVisible).toBe(false);
         expect(mangaList.vm.$data.selectedEntriesIDs).toEqual([]);
       });
+      it('@editEntry - shows edit manga entry dialog with specific entry', () => {
+        mangaList.find(TheMangaList).vm.$emit('editEntry', entry1.id);
+
+        expect(mangaList.vm.$data.editDialogVisible).toBe(true);
+        expect(mangaList.vm.$data.selectedEntriesIDs).toEqual([entry1.id]);
+      });
     });
   });
   describe('when deleting manga entries', () => {
@@ -214,6 +220,31 @@ describe('MangaList.vue', () => {
     });
   });
   describe(':data', () => {
+    describe(':selectedEntriesIDs', () => {
+      let mangaList;
+      let dialog;
+
+      beforeEach(() => {
+        mangaList = shallowMount(MangaList, {
+          store,
+          localVue,
+          data() { return { currentListID: firstMangaList.id }; },
+        });
+        dialog = mangaList.find({ ref: 'editMangaEntryDialog' });
+      });
+
+      it('shows plural title in edit entry modal if there are more than one entry selected', () => {
+        mangaList.setData({ selectedEntriesIDs: [entry1.id, entry2.id] });
+
+        expect(dialog.attributes('title')).toEqual('Edit Manga Entries');
+      });
+
+      it('shows singular title in edit entry modal if there is one entry selected', () => {
+        mangaList.setData({ selectedEntriesIDs: [entry1.id] });
+
+        expect(dialog.attributes('title')).toEqual('Edit Manga Entry');
+      });
+    })
     it(':searchTerm - if present, filters manga entries', () => {
       const mangaList = shallowMount(MangaList, {
         store,

--- a/tests/views/MangaList.spec.js
+++ b/tests/views/MangaList.spec.js
@@ -64,7 +64,7 @@ describe('MangaList.vue', () => {
         localVue,
         data() {
           return {
-            selectedSeriesIDs: [entry1.id],
+            selectedEntriesIDs: [entry1.id],
             currentListID: firstMangaList.id,
           };
         },
@@ -93,7 +93,7 @@ describe('MangaList.vue', () => {
         localVue,
         data() {
           return {
-            selectedSeriesIDs: [entry1.id],
+            selectedEntriesIDs: [entry1.id],
             currentListID: firstMangaList.id,
           };
         },
@@ -113,7 +113,7 @@ describe('MangaList.vue', () => {
         mangaList.find(EditMangaEntries).vm.$emit('editComplete');
 
         expect(mangaList.vm.$data.editDialogVisible).toBe(false);
-        expect(mangaList.vm.$data.selectedSeriesIDs).toEqual([]);
+        expect(mangaList.vm.$data.selectedEntriesIDs).toEqual([]);
       });
     });
   });
@@ -129,7 +129,7 @@ describe('MangaList.vue', () => {
         localVue,
         data() {
           return {
-            selectedSeriesIDs: [entry1.id],
+            selectedEntriesIDs: [entry1.id],
             currentListID: firstMangaList.id,
           };
         },
@@ -203,7 +203,7 @@ describe('MangaList.vue', () => {
       mangaList.find(TheMangaList).vm.$emit('seriesSelected', ['1']);
 
       expect(mangaList.html()).toContain('Remove');
-      expect(mangaList.vm.$data.selectedSeriesIDs).toContain('1');
+      expect(mangaList.vm.$data.selectedEntriesIDs).toContain('1');
     });
 
     it('@importCompleted - refreshes manga list', () => {


### PR DESCRIPTION
This PR adds two new improvements:

1. Ability to edit a single entry, without making use of the bulk edit
2. Hides action buttons by default and shows them only on hover

![Kapture 2020-02-05 at 19 16 41](https://user-images.githubusercontent.com/4270980/73874873-2f823c00-484c-11ea-8752-4747685fa0c0.gif)
