### PR TITLE
Add new tooltips

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "vue-analytics": "^5.22.1",
     "vue-rollbar": "^1.0.0",
     "vue-router": "^3.1.5",
+    "vue-tippy": "^4.4.0",
     "vuex": "^3.1.2",
     "vuex-persist": "^2.2.0"
   },

--- a/src/components/TheMangaList.vue
+++ b/src/components/TheMangaList.vue
@@ -75,20 +75,16 @@
             @click="editMangaEntry(scope.row)"
             circle
           )
-          el-tooltip(
-            effect="dark"
+          el-button(
             content="Set last read to the latest chapter"
-            placement="top-start"
-            :enterable="false"
+            v-if="unread(scope.row)"
+            ref="updateEntryButton"
+            icon="el-icon-check"
+            size="mini"
+            @click="setLastRead(scope.row)"
+            circle
+            v-tippy
           )
-            el-button(
-              v-if="unread(scope.row)"
-              ref="updateEntryButton"
-              icon="el-icon-check"
-              size="mini"
-              @click="setLastRead(scope.row)"
-              circle
-            )
     .flex.flex-row.justify-center
       el-pagination.sm_shadow-lg.my-5.p-0(
         layout="prev, pager, next"
@@ -102,7 +98,7 @@
 <script>
   import { mapState, mapMutations } from 'vuex';
   import {
-    Table, TableColumn, Link, Button, Message, Tooltip, Pagination,
+    Table, TableColumn, Link, Button, Message, Pagination,
   } from 'element-ui';
   import dayjs from 'dayjs';
   import he from 'he';
@@ -119,7 +115,6 @@
       'el-table-column': TableColumn,
       'el-link': Link,
       'el-button': Button,
-      'el-tooltip': Tooltip,
       'el-pagination': Pagination,
     },
     filters: {

--- a/src/packs/main.js
+++ b/src/packs/main.js
@@ -2,17 +2,25 @@ import Vue from 'vue';
 import VueAnalytics from 'vue-analytics';
 import Rollbar from 'vue-rollbar';
 import { Loading } from 'element-ui';
+import VueTippy from 'vue-tippy';
 import Home from '@/views/Home.vue';
 import '@/plugins/element.js';
 import '@/components/_globals.js';
 import '@/stylesheets/global.scss';
 import '@/stylesheets/tailwind.css';
+import 'tippy.js/themes/light.css';
 
 import router from '@/router/';
 import store from '@/store/index';
 
 Vue.config.productionTip = false;
 
+Vue.use(VueTippy, {
+  directive: 'tippy',
+  animateFill: false,
+  animation: 'shift-toward',
+  theme: 'light',
+});
 Vue.use(Loading);
 Vue.use(VueAnalytics, {
   id: 'UA-145065333-1',

--- a/yarn.lock
+++ b/yarn.lock
@@ -5576,6 +5576,11 @@ human-signals@^1.1.1:
   resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-1.1.1.tgz#c5b1cd14f50aeae09ab6c59fe63ba3395fe4dfa3"
   integrity sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==
 
+humps@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/humps/-/humps-2.0.1.tgz#dd02ea6081bd0568dc5d073184463957ba9ef9aa"
+  integrity sha1-3QLqYIG9BWjcXQcxhEY5V7qe+ao=
+
 iconv-lite@0.4.24, iconv-lite@^0.4.24, iconv-lite@^0.4.4:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
@@ -8389,6 +8394,11 @@ pn@^1.1.0:
   resolved "https://registry.yarnpkg.com/pn/-/pn-1.1.0.tgz#e2f4cef0e219f463c179ab37463e4e1ecdccbafb"
   integrity sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA==
 
+popper.js@^1.14.7:
+  version "1.16.1"
+  resolved "https://registry.yarnpkg.com/popper.js/-/popper.js-1.16.1.tgz#2a223cb3dc7b6213d740e40372be40de43e65b1b"
+  integrity sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ==
+
 portfinder@^1.0.25:
   version "1.0.25"
   resolved "https://registry.yarnpkg.com/portfinder/-/portfinder-1.0.25.tgz#254fd337ffba869f4b9d37edc298059cb4d35eca"
@@ -10561,6 +10571,13 @@ timsort@^0.3.0:
   resolved "https://registry.yarnpkg.com/timsort/-/timsort-0.3.0.tgz#405411a8e7e6339fe64db9a234de11dc31e02bd4"
   integrity sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q=
 
+tippy.js@^4.3.5:
+  version "4.3.5"
+  resolved "https://registry.yarnpkg.com/tippy.js/-/tippy.js-4.3.5.tgz#882bff8d92f09bb0546d2826d5668c0560006f54"
+  integrity sha512-NDq3efte8nGK6BOJ1dDN1/WelAwfmh3UtIYXXck6+SxLzbIQNZE/cmRSnwScZ/FyiKdIcvFHvYUgqmoGx8CcyA==
+  dependencies:
+    popper.js "^1.14.7"
+
 tmp@^0.0.33:
   version "0.0.33"
   resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.33.tgz#6d34335889768d21b2bcda0aa277ced3b1bfadf9"
@@ -11093,6 +11110,14 @@ vue-template-es2015-compiler@^1.6.0, vue-template-es2015-compiler@^1.9.0:
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/vue-template-es2015-compiler/-/vue-template-es2015-compiler-1.9.1.tgz#1ee3bc9a16ecbf5118be334bb15f9c46f82f5825"
   integrity sha512-4gDntzrifFnCEvyoO8PqyJDmguXgVPxKiIxrBKjIowvL9l+N66196+72XVYR8BBf1Uv1Fgt3bGevJ+sEmxfZzw==
+
+vue-tippy@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/vue-tippy/-/vue-tippy-4.4.0.tgz#184d9d35efbd08e17c410ddab248999c039b89d5"
+  integrity sha512-3UgRjCgVHZFP613dU5tMv2lEgoiGP8A/HJ1OSmbaitL2A4bpv5N5sXTXVBkDDJRZJ/ZLr6NHIRrB/t50ajXpKA==
+  dependencies:
+    humps "^2.0.1"
+    tippy.js "^4.3.5"
 
 vue@^2.6.11:
   version "2.6.11"


### PR DESCRIPTION
ElementUI Tooltips were pretty garbage, using a deprecated library and having very few options for configuration. Most importantly, its animation started to look very bad with the changes in #163, that would hide action buttons. The tooltip will remain visible for way too long and there was no easy way to fix it with ElementUI.

This PR adds [vue-tippy](https://kabbouchi.github.io/vue-tippy/4.0/) instead, that provides fantastic tooltips with good configuration and animations.

![Kapture 2020-02-05 at 20 30 36](https://user-images.githubusercontent.com/4270980/73880665-bf2ce800-4856-11ea-9c98-94f4ed5f7291.gif)
