### PR TITLE
Add await for the list retrieval

### DIFF
--- a/src/views/MangaList.vue
+++ b/src/views/MangaList.vue
@@ -186,8 +186,8 @@
         );
       },
     },
-    mounted() {
-      this.retrieveLists();
+    async mounted() {
+      await this.retrieveLists();
       this.retrieveEntries();
     },
     methods: {


### PR DESCRIPTION
There was a race condition for the refresh request.

When token would get outdated, we would do 2 refresh requests, as we would call lists and entries endpoints in parallel. So the second refresh would fail and invalidate the session.

Instead, we want to always do only one refresh request, and for that, we want to wait for the lists request to finish, before doing entries