### PR TITLE
Specify manga issue

### DIFF
--- a/src/components/manga_entries/EditMangaEntries.vue
+++ b/src/components/manga_entries/EditMangaEntries.vue
@@ -10,21 +10,14 @@
         :label="list.attributes.name"
         :value="list.id"
       )
-    .mt-8.-mb-2
+    .mt-8.-mb-2.text-right
+      el-button(@click="closeEditModal('cancelEdit')") Cancel
       el-button(
-        ref="reportEntryErrorButton"
-        type="danger"
-        @click="reportEntryError"
+        ref="updateEntryButton"
+        type="primary"
+        @click="updateMangaEntries"
       )
-        | Wrong Info?
-      .float-right
-        el-button(@click="closeEditModal('cancelEdit')") Cancel
-        el-button(
-          ref="updateEntryButton"
-          type="primary"
-          @click="updateMangaEntries"
-        )
-          | Update
+        | Update
 </template>
 
 <script>
@@ -32,9 +25,6 @@
   import {
     Message, Loading, Button, Select, Option,
   } from 'element-ui';
-  import {
-    postMangaEntriesErrors,
-  } from '@/services/endpoints/MangaEntriesErrors';
   import { bulkUpdateMangaEntry } from '@/services/api';
 
   export default {
@@ -78,21 +68,6 @@
           this.closeEditModal('editComplete');
         } else {
           Message.error("Couldn't update. Try refreshing the page");
-        }
-      },
-      async reportEntryError() {
-        const successful = await postMangaEntriesErrors(this.selectedEntriesIDs);
-
-        if (successful) {
-          this.closeEditModal('editComplete');
-          Message.success(
-            'Issue reported. Entries will be updated'
-              + ' automatically shortly or investigated in detail later'
-          );
-        } else {
-          Message.error(
-            'Failed to report. Try reloading the page before trying again'
-          );
         }
       },
       closeEditModal(emitEvent) {

--- a/src/components/manga_entries/ReportMangaEntries.vue
+++ b/src/components/manga_entries/ReportMangaEntries.vue
@@ -1,0 +1,73 @@
+<template lang="pug">
+  #report-manga-entries
+    el-select.rounded.w-full(
+      v-model="currentIssue"
+      placeholder="Select issue type"
+    )
+      el-option(
+        v-for="issue in issues"
+        :key="issue.type"
+        :label="issue.value"
+        :value="issue.type"
+      )
+    p.text-gray-600.text-xs.break-normal
+      | Select this option, if manga information is outdated or incorrect.
+      | Manga will attempt to update automatically, otherwise it will be
+      | investigated in detail later.
+    .mt-8.-mb-2.text-right
+      el-button(@click="$emit('closeDialog')") Cancel
+      el-button(ref="reportEntriesButton" type="danger" @click="report")
+        | Report
+</template>
+
+<script>
+  import {
+    Dialog, Button, Select, Option, Message, Loading,
+  } from 'element-ui';
+
+  import {
+    postMangaEntriesErrors,
+  } from '@/services/endpoints/MangaEntriesErrors';
+
+  export default {
+    name: 'ReportMangaEntries',
+    components: {
+      'el-dialog': Dialog,
+      'el-select': Select,
+      'el-option': Option,
+      'el-button': Button,
+    },
+    props: {
+      selectedEntriesIDs: {
+        type: Array,
+        required: true,
+      },
+    },
+    data() {
+      return {
+        issues: [{ type: 0, value: 'Incorrect Manga Data' }],
+        currentIssue: 0,
+      };
+    },
+    methods: {
+      async report() {
+        const loading = Loading.service({ target: '.report-manga-entry-dialog' });
+
+        const successful = await postMangaEntriesErrors(
+          this.selectedEntriesIDs, this.currentIssue
+        );
+
+        loading.close();
+
+        if (successful) {
+          this.$emit('closeDialog');
+          Message.success('Issue reported successfully');
+        } else {
+          Message.error(
+            'Failed to report. Try reloading the page before trying again'
+          );
+        }
+      },
+    },
+  };
+</script>

--- a/src/services/endpoints/MangaEntriesErrors.js
+++ b/src/services/endpoints/MangaEntriesErrors.js
@@ -1,8 +1,8 @@
 import { secure } from '@/modules/axios';
 
 /* eslint-disable import/prefer-default-export */
-export const postMangaEntriesErrors = entriesIDs => secure
-  .post('/api/v1/manga_entries_errors/', { ids: entriesIDs })
+export const postMangaEntriesErrors = (entriesIDs, issueID) => secure
+  .post('/api/v1/manga_entries_errors/', { ids: entriesIDs, issue_id: issueID })
   .then(() => true)
   .catch(() => false);
 /* eslint-enable import/prefer-default-export */

--- a/src/views/MangaList.vue
+++ b/src/views/MangaList.vue
@@ -36,24 +36,37 @@
         .bulk-actions.inline-block.max-sm_mb-5.max-sm_float-right
           el-button.sm_shadow-md(
             v-show="entriesSelected"
+            content="Delete"
             ref="removeSeriesButton"
+            icon="el-icon-delete"
             type="danger"
             size="medium"
             @click="removeSeries"
-            round
+            circle
+            v-tippy
           )
-            i.el-icon-delete.mr-1
-            | Remove
           el-button.sm_shadow-md(
             v-show="entriesSelected"
+            content="Edit"
             ref="editMangaEntriesButton"
+            icon="el-icon-edit-outline"
             type="info"
             size="medium"
             @click="editDialogVisible = true"
-            round
+            circle
+            v-tippy
           )
-            i.el-icon-edit.mr-1
-            | Edit
+          el-button.sm_shadow-md(
+            v-show="entriesSelected"
+            content="Report manga issues"
+            ref="reportMangaEntriesButton"
+            icon="el-icon-document-delete"
+            type="warning"
+            size="medium"
+            @click="reportDialogVisible = true"
+            circle
+            v-tippy
+          )
         .actions.inline-block.float-right
           el-button.sm_shadow-md(
             type="success"
@@ -98,7 +111,7 @@
         )
       el-dialog(
         ref='editMangaEntryDialog'
-        :title="editMangaEntriesDialogTitle"
+        :title="mangaEntriesDialogTitle('Edit')"
         custom-class="custom-dialog edit-manga-entry-dialog"
         width="400px"
         :visible.sync="editDialogVisible"
@@ -106,7 +119,18 @@
         edit-manga-entries(
           :selectedEntriesIDs='selectedEntriesIDs'
           @cancelEdit='editDialogVisible = false'
-          @editComplete='resetEditEntries'
+          @editComplete="resetEntries('editDialogVisible')"
+        )
+      el-dialog(
+        ref='reportMangaEntryDialog'
+        custom-class="custom-dialog report-manga-entry-dialog"
+        width="400px"
+        :title="mangaEntriesDialogTitle('Report')"
+        :visible.sync="reportDialogVisible"
+      )
+        report-manga-entries(
+          :selectedEntriesIDs='selectedEntriesIDs'
+          @closeDialog="resetEntries('reportDialogVisible')"
         )
 </template>
 
@@ -122,6 +146,7 @@
   import Importers from '@/components/TheImporters';
   import AddMangaEntry from '@/components/manga_entries/AddMangaEntry';
   import EditMangaEntries from '@/components/manga_entries/EditMangaEntries';
+  import ReportMangaEntries from '@/components/manga_entries/ReportMangaEntries';
   import TheMangaList from '@/components/TheMangaList';
   import { bulkDeleteMangaEntries } from '@/services/api';
 
@@ -131,6 +156,7 @@
       Importers,
       AddMangaEntry,
       EditMangaEntries,
+      ReportMangaEntries,
       TheMangaList,
       'el-button': Button,
       'el-dialog': Dialog,
@@ -148,6 +174,7 @@
         dialogVisible: false,
         importDialogVisible: false,
         editDialogVisible: false,
+        reportDialogVisible: false,
         alertMessage: `
           UI improvements, add manga using chapter URL, bug fixes and more in
           the newest update. Click to learn more
@@ -161,11 +188,6 @@
       ...mapGetters('lists', [
         'getEntriesByListId',
       ]),
-      editMangaEntriesDialogTitle() {
-        return this.selectedEntriesIDs.length > 1
-          ? 'Edit Manga Entries'
-          : 'Edit Manga Entry';
-      },
       currentListEntries() {
         return this.getEntriesByListId(this.currentListID);
       },
@@ -199,6 +221,11 @@
         'removeEntries',
         'setListsLoading',
       ]),
+      mangaEntriesDialogTitle(action) {
+        return this.selectedEntriesIDs.length > 1
+          ? `${action} Manga Entries`
+          : `${action} Manga Entry`;
+      },
       handleSelection(selectedEntriesIDs) {
         this.entriesSelected = selectedEntriesIDs.length > 0;
         this.selectedEntriesIDs = selectedEntriesIDs;
@@ -227,8 +254,8 @@
         // TODO: Figure out based on relationships if there was a new list added
         this.retrieveLists();
       },
-      resetEditEntries() {
-        this.editDialogVisible = false;
+      resetEntries(dialogName) {
+        this[dialogName] = false;
         this.resetSelectedAttributes();
       },
       clearTableSelection() {

--- a/tests/components/TheMangaList.spec.js
+++ b/tests/components/TheMangaList.spec.js
@@ -12,6 +12,7 @@ import * as api from '@/services/api';
 const localVue = createLocalVue();
 
 localVue.directive('loading', true);
+localVue.directive('tippy', true);
 localVue.use(Vuex);
 
 describe('TheMangaList.vue', () => {

--- a/tests/components/manga_entries/EditMangaEntries.spec.js
+++ b/tests/components/manga_entries/EditMangaEntries.spec.js
@@ -5,7 +5,6 @@ import flushPromises from 'flush-promises';
 import EditMangaEntries from '@/components/manga_entries/EditMangaEntries.vue';
 import lists from '@/store/modules/lists';
 import * as api from '@/services/api';
-import * as mangaEntriesErrors from '@/services/endpoints/MangaEntriesErrors';
 
 import mangaEntryFactory from '../../factories/mangaEntry';
 import mangaListFactory from '../../factories/mangaList';
@@ -115,53 +114,6 @@ describe('EditMangaEntries.vue', () => {
         expect(store.state.lists.entries).not.toContain(updatedMangaEntry);
         expect(errorMessageMock).toHaveBeenCalledWith(
           "Couldn't update. Try refreshing the page"
-        );
-      });
-    });
-  });
-  describe('when reporting manga entries', () => {
-    let postMangaEntriesErrorsMock;
-
-    beforeEach(() => {
-      postMangaEntriesErrorsMock = jest.spyOn(
-        mangaEntriesErrors, 'postMangaEntriesErrors'
-      );
-    });
-
-    afterEach(() => {
-      expect(postMangaEntriesErrorsMock).toHaveBeenCalledWith(['1']);
-    });
-
-    describe('if report was successful', () => {
-      it('shows successful message', async () => {
-        const infoMessageMock = jest.spyOn(Message, 'success');
-
-        postMangaEntriesErrorsMock.mockResolvedValue(true);
-
-        editMangaEntries.vm.reportEntryError();
-
-        await flushPromises();
-
-        expect(editMangaEntries.emitted('editComplete')).toBeTruthy();
-        expect(infoMessageMock).toHaveBeenCalledWith(
-          'Issue reported. Entries will be updated'
-            + ' automatically shortly or investigated in detail later'
-        );
-      });
-    });
-
-    describe('if report was unsuccessful', () => {
-      it('shows failure message', async () => {
-        const errorMessageMock = jest.spyOn(Message, 'error');
-
-        postMangaEntriesErrorsMock.mockResolvedValue(false);
-
-        editMangaEntries.vm.reportEntryError();
-
-        await flushPromises();
-
-        expect(errorMessageMock).toHaveBeenCalledWith(
-          'Failed to report. Try reloading the page before trying again'
         );
       });
     });

--- a/tests/components/manga_entries/ReportMangaEntries.spec.js
+++ b/tests/components/manga_entries/ReportMangaEntries.spec.js
@@ -1,0 +1,63 @@
+import { shallowMount } from '@vue/test-utils';
+import { Message } from 'element-ui';
+import flushPromises from 'flush-promises';
+import ReportMangaEntries from '@/components/manga_entries/ReportMangaEntries.vue';
+import * as mangaEntriesErrors from '@/services/endpoints/MangaEntriesErrors';
+
+describe('ReportMangaEntries.vue', () => {
+  let reportMangaEntries;
+  let postMangaEntriesErrorsMock;
+
+  beforeEach(() => {
+    reportMangaEntries = shallowMount(ReportMangaEntries, {
+      data() {
+        return {
+          currentIssue: 0,
+        };
+      },
+      propsData: {
+        selectedEntriesIDs: ['1'],
+      },
+    });
+    postMangaEntriesErrorsMock = jest.spyOn(
+      mangaEntriesErrors, 'postMangaEntriesErrors'
+    );
+  });
+
+  afterEach(() => {
+    expect(postMangaEntriesErrorsMock).toHaveBeenCalledWith(['1'], 0);
+  });
+
+  describe('if report was successful', () => {
+    it('shows successful message', async () => {
+      const infoMessageMock = jest.spyOn(Message, 'success');
+
+      postMangaEntriesErrorsMock.mockResolvedValue(true);
+
+      reportMangaEntries.vm.report();
+
+      await flushPromises();
+
+      expect(reportMangaEntries.emitted('closeDialog')).toBeTruthy();
+      expect(infoMessageMock).toHaveBeenCalledWith(
+        'Issue reported successfully'
+      );
+    });
+  });
+
+  describe('if report was unsuccessful', () => {
+    it('shows failure message', async () => {
+      const errorMessageMock = jest.spyOn(Message, 'error');
+
+      postMangaEntriesErrorsMock.mockResolvedValue(false);
+
+      reportMangaEntries.vm.report();
+
+      await flushPromises();
+
+      expect(errorMessageMock).toHaveBeenCalledWith(
+        'Failed to report. Try reloading the page before trying again'
+      );
+    });
+  });
+});

--- a/tests/services/endpoints/MangaEntriesErrors.spec.js
+++ b/tests/services/endpoints/MangaEntriesErrors.spec.js
@@ -8,17 +8,23 @@ describe('MangaEntriesErrors', () => {
 
   describe('postMangaEntriesErrors()', () => {
     it('makes a request to the resource and returns true', async () => {
-      axios.post.mockResolvedValue({ status: 200 });
+      const reportMangaEntriesMock = jest.spyOn(axios, 'post');
 
-      const successful = await resource.postMangaEntriesErrors({ ids: ['1'] });
+      reportMangaEntriesMock.mockResolvedValue({ status: 200 });
+
+      const successful = await resource.postMangaEntriesErrors(['1'], 0);
 
       expect(successful).toBeTruthy();
+      expect(reportMangaEntriesMock).toHaveBeenCalledWith(
+        '/api/v1/manga_entries_errors/',
+        { ids: ['1'], issue_id: 0 }
+      );
     });
 
     it('makes a request to the resource and returns false if failed', async () => {
       axios.post.mockRejectedValue({ status: 500 });
 
-      const successful = await resource.postMangaEntriesErrors({ ids: [] });
+      const successful = await resource.postMangaEntriesErrors([], 0);
       expect(successful).toBeFalsy();
     });
   });

--- a/tests/views/MangaList.spec.js
+++ b/tests/views/MangaList.spec.js
@@ -19,6 +19,7 @@ localVue.use(Vuex);
 
 // To avoid missing directive Vue warnings
 localVue.directive('loading', true);
+localVue.directive('tippy', true);
 
 describe('MangaList.vue', () => {
   let store;
@@ -205,10 +206,20 @@ describe('MangaList.vue', () => {
       });
     });
 
-    it('@seriesSelected - toggles delete button and sets selected series', () => {
+    it('@seriesSelected - toggles bulk actions and sets selected series', () => {
+      const deleteButton = mangaList.find({ ref: 'removeSeriesButton' });
+      const editButton = mangaList.find({ ref: 'editMangaEntriesButton' });
+      const reportButton = mangaList.find({ ref: 'reportMangaEntriesButton' });
+
+      expect(deleteButton.isVisible()).not.toBeTruthy();
+      expect(editButton.isVisible()).not.toBeTruthy();
+      expect(reportButton.isVisible()).not.toBeTruthy();
+
       mangaList.find(TheMangaList).vm.$emit('seriesSelected', ['1']);
 
-      expect(mangaList.html()).toContain('Remove');
+      expect(deleteButton.isVisible()).toBeTruthy();
+      expect(editButton.isVisible()).toBeTruthy();
+      expect(reportButton.isVisible()).toBeTruthy();
       expect(mangaList.vm.$data.selectedEntriesIDs).toContain('1');
     });
 


### PR DESCRIPTION
This PR adds the ability to specify manga issue. In the future, you'll be able to specify different issues with the manga, so I need to get that extra information. I will also be able to expand this to provide custom reason, with full-text reporting.

This PR also moves the reporting outside the Edit Manga dialog, as a lot of users wouldn't even know that feature existed. 

Finally, as we are growing in number of bulk actions, I decided to start using icons only, with tooltips provided, for a neater look, which will allow me to add more actions, if needed

![report](https://user-images.githubusercontent.com/4270980/74087979-3c3fa380-4a89-11ea-954a-9c6858fba8d5.gif)
