### PR TITLE
Fix table loading animation not starting immediately 

### DIFF
--- a/src/store/modules/lists.js
+++ b/src/store/modules/lists.js
@@ -22,14 +22,11 @@ const actions = {
       .catch((request) => { Message.error(request.response.data.error); });
   },
   getEntries({ commit }) {
-    commit('setListsLoading', true);
-
     return secure.get('/api/v1/manga_entries/')
       .then((response) => {
         commit('setEntries', response.data.data);
       })
-      .catch((request) => { Message.error(request.response.data.error); })
-      .then(() => { commit('setListsLoading', false); });
+      .catch((request) => { Message.error(request.response.data.error); });
   },
 };
 

--- a/src/views/MangaList.vue
+++ b/src/views/MangaList.vue
@@ -17,6 +17,7 @@
         el-select.sm_shadow-md.rounded.float-right.w-48(
           v-model="currentListID"
           placeholder="Select"
+          :disabled="listsLoading"
         )
           el-option(
             v-for="list in lists"
@@ -184,6 +185,7 @@
     computed: {
       ...mapState('lists', [
         'lists',
+        'listsLoading',
       ]),
       ...mapGetters('lists', [
         'getEntriesByListId',
@@ -209,8 +211,12 @@
       },
     },
     async mounted() {
+      this.setListsLoading(true);
+
       await this.retrieveLists();
-      this.retrieveEntries();
+      await this.retrieveEntries();
+
+      this.setListsLoading(false);
     },
     methods: {
       ...mapActions('lists', [

--- a/tests/store/modules/lists.spec.js
+++ b/tests/store/modules/lists.spec.js
@@ -179,8 +179,6 @@ describe('lists', () => {
 
         expect(axiosSpy).toHaveBeenCalledWith('/api/v1/manga_entries/');
         expect(commit).toHaveBeenCalledWith('setEntries', entries);
-        expect(commit).toHaveBeenCalledWith('setListsLoading', true);
-        expect(commit).toHaveBeenLastCalledWith('setListsLoading', false);
       });
 
       it('shows error message if request has failed', async () => {

--- a/tests/views/MangaList.spec.js
+++ b/tests/views/MangaList.spec.js
@@ -284,4 +284,23 @@ describe('MangaList.vue', () => {
       expect(mangaList.vm.filteredEntries).toEqual([entry2]);
     });
   });
+  describe(':lifecycle', () => {
+    it(':mounted() - loads lists and entries, while toggling loading', async () => {
+      const retrieveListsSpy   = jest.spyOn(MangaList.methods, 'retrieveLists');
+      const retrieveEntriesSpy = jest.spyOn(MangaList.methods, 'retrieveEntries');
+
+      retrieveListsSpy.mockResolvedValue();
+
+      shallowMount(MangaList, {
+        store,
+        localVue,
+        data() { return { currentListID: firstMangaList.id }; },
+      });
+
+      await flushPromises();
+
+      expect(retrieveListsSpy).toHaveBeenCalled();
+      expect(retrieveEntriesSpy).toHaveBeenCalled();
+    });
+  });
 });


### PR DESCRIPTION
I was having a bit of a delay for table loading, as I moved it to entries endpoint, which waits for lists to load. Instead, I should be adding loading spinner the moment I am trying to get entries.

I decided to move it out of the store module and directly into the component, as I think it is more fitting to be there