### PR TITLE
AddMangaEntry uses server response message

### DIFF
--- a/src/components/manga_entries/AddMangaEntry.vue
+++ b/src/components/manga_entries/AddMangaEntry.vue
@@ -53,14 +53,10 @@
             this.closeModal(loading);
           })
           .catch((error) => {
-            if (error.response.status === 400) {
-              Message.error('URL is incorrect');
-              loading.close();
-            } else if (error.response.status === 404) {
-              Message.info('Manga was not found');
-              loading.close();
-            } else if (error.response.status === 406) {
-              Message.info('Manga already added');
+            const { status, data } = error.response;
+
+            if (status === 404 || status === 406) {
+              Message.info(data);
               loading.close();
             } else {
               Message.error('Something went wrong');

--- a/tests/components/manga_entries/AddMangaEntry.spec.js
+++ b/tests/components/manga_entries/AddMangaEntry.spec.js
@@ -62,41 +62,36 @@ describe('AddMangaEntry.vue', () => {
       expect(addMangaEntry.emitted('dialogClosed')).toBeTruthy();
     });
 
-    it('shows Manga not found message if API returns nothing', async () => {
-      const infoMessageMock   = jest.spyOn(Message, 'info');
-      const addMangaEntryMock = jest.spyOn(api, 'addMangaEntry');
+    describe('when receiving 404 status', () => {
+      it('shows info message with payload data', async () => {
+        const infoMessageMock   = jest.spyOn(Message, 'info');
+        const addMangaEntryMock = jest.spyOn(api, 'addMangaEntry');
 
-      addMangaEntryMock.mockRejectedValue({ response: { status: 404 } });
+        addMangaEntryMock.mockRejectedValue(
+          { response: { status: 404, data: 'Manga was not found' } }
+        );
 
-      addMangaEntry.vm.mangaDexSearch();
+        addMangaEntry.vm.mangaDexSearch();
 
-      await flushPromises();
-      expect(infoMessageMock).toHaveBeenCalledWith('Manga was not found');
+        await flushPromises();
+        expect(infoMessageMock).toHaveBeenCalledWith('Manga was not found');
+      });
     });
 
-    it('shows Manga already added if it has already been added', async () => {
-      const addMangaEntryMock = jest.spyOn(api, 'addMangaEntry');
-      const infoMessageMock = jest.spyOn(Message, 'info');
+    describe('when receiving 406 status', () => {
+      it('shows info message with payload data', async () => {
+        const infoMessageMock   = jest.spyOn(Message, 'info');
+        const addMangaEntryMock = jest.spyOn(api, 'addMangaEntry');
 
-      addMangaEntryMock.mockRejectedValue({ response: { status: 406 } });
+        addMangaEntryMock.mockRejectedValue(
+          { response: { status: 406, data: 'Manga already added' } }
+        );
 
-      addMangaEntry.vm.mangaDexSearch();
+        addMangaEntry.vm.mangaDexSearch();
 
-      await flushPromises();
-
-      expect(infoMessageMock).toHaveBeenCalledWith('Manga already added');
-    });
-
-    it('shows URL is incorrect message if response is 400', async () => {
-      const infoMessageMock   = jest.spyOn(Message, 'error');
-      const addMangaEntryMock = jest.spyOn(api, 'addMangaEntry');
-
-      addMangaEntryMock.mockRejectedValue({ response: { status: 400 } });
-
-      addMangaEntry.vm.mangaDexSearch();
-
-      await flushPromises();
-      expect(infoMessageMock).toHaveBeenCalledWith('URL is incorrect');
+        await flushPromises();
+        expect(infoMessageMock).toHaveBeenCalledWith('Manga already added');
+      });
     });
 
     it('shows error message on unsuccessful API lookup', async () => {


### PR DESCRIPTION
Instead of hardcoding error messages, the client will now use the ones returned from the server instead, allowing us to scale more easily and add translations in the future