### PR TITLE
Switch to using pretty last read chapter

### DIFF
--- a/src/components/TheImporters.vue
+++ b/src/components/TheImporters.vue
@@ -109,7 +109,7 @@
             .map(url => ({
               seriesURL: url.full_title_url,
               chapterURL: url.generated_current_data.url,
-              lastRead: url.title_data.current_chapter,
+              lastRead: url.generated_current_data.number,
             }));
         });
 

--- a/tests/components/TheImporters.spec.js
+++ b/tests/components/TheImporters.spec.js
@@ -27,9 +27,7 @@ describe('TheImporters.vue', () => {
               full_title_url: 'example.url/manga/1',
               generated_current_data: {
                 url: 'example.url/chapter/1',
-              },
-              title_data: {
-                current_chapter: '38201:--:v5/c34',
+                number: 'v5/c34',
               },
               site_data: {
                 site: 'mangadex.org',


### PR DESCRIPTION
Trackr.moe export provides formatted last chapter read, but I was using the one extracted, which I had to then adjust myself on the backend. This PR makes sure I don't have to do that extra work and use formatted chapters from Trackr.moe