### PR TITLE
MangaList correctly destroys Edit dialog contents

### DIFF
--- a/src/components/manga_entries/EditMangaEntries.vue
+++ b/src/components/manga_entries/EditMangaEntries.vue
@@ -11,7 +11,7 @@
         :value="list.id"
       )
     .mt-8.-mb-2.text-right
-      el-button(@click="closeEditModal('cancelEdit')") Cancel
+      el-button(@click="$emit('cancelEdit')") Cancel
       el-button(
         ref="updateEntryButton"
         type="primary"
@@ -65,14 +65,10 @@
         if (response) {
           Message.info(`${this.selectedEntries.length} entries updated`);
           response.map(e => this.updateEntry(e));
-          this.closeEditModal('editComplete');
+          this.$emit('editComplete');
         } else {
           Message.error("Couldn't update. Try refreshing the page");
         }
-      },
-      closeEditModal(emitEvent) {
-        this.$emit(emitEvent);
-        this.newListID = null;
       },
     },
   };

--- a/src/views/MangaList.vue
+++ b/src/views/MangaList.vue
@@ -116,8 +116,11 @@
         custom-class="custom-dialog edit-manga-entry-dialog"
         width="400px"
         :visible.sync="editDialogVisible"
+        @open="toggleBody"
+        @closed="toggleBody"
       )
         edit-manga-entries(
+          v-if="editDialogBodyVisible"
           :selectedEntries='selectedEntries'
           @cancelEdit='editDialogVisible = false'
           @editComplete="resetEntries('editDialogVisible')"
@@ -175,6 +178,7 @@
         dialogVisible: false,
         importDialogVisible: false,
         editDialogVisible: false,
+        editDialogBodyVisible: false,
         reportDialogVisible: false,
         alertMessage: `
           UI improvements, add manga using chapter URL, bug fixes and more in
@@ -227,6 +231,9 @@
         'removeEntries',
         'setListsLoading',
       ]),
+      toggleBody() {
+        this.editDialogBodyVisible = !this.editDialogBodyVisible;
+      },
       mangaEntriesDialogTitle(action) {
         return this.selectedEntries.length > 1
           ? `${action} Manga Entries`

--- a/tests/components/manga_entries/EditMangaEntries.spec.js
+++ b/tests/components/manga_entries/EditMangaEntries.spec.js
@@ -70,12 +70,11 @@ describe('EditMangaEntries.vue', () => {
         updateMangaEntriesMock.mockResolvedValue([updatedMangaEntry]);
       });
 
-      it('emits editComplete and sets newListID to null', async () => {
+      it('emits editComplete', async () => {
         editMangaEntries.vm.updateMangaEntries();
 
         await flushPromises();
 
-        expect(editMangaEntries.vm.$data.newListID).toEqual(null);
         expect(editMangaEntries.emitted('editComplete')).toBeTruthy();
       });
 

--- a/tests/views/MangaList.spec.js
+++ b/tests/views/MangaList.spec.js
@@ -106,19 +106,44 @@ describe('MangaList.vue', () => {
     });
 
     describe('@events', () => {
-      it('@cancelEdit - closes edit manga entries dialog', () => {
-        mangaList.find(EditMangaEntries).vm.$emit('cancelEdit');
+      it('@open - opening edit modal renders edit manga entry component', () => {
+        mangaList.find({ ref: 'editMangaEntryDialog' }).vm.$emit('open');
+
+        expect(mangaList.find(EditMangaEntries).exists()).toBeTruthy();
       });
+
+      it('@closed - when edit modal finished closing, destroys edit manga entry component', () => {
+        mangaList.setData({ editDialogBodyVisible: true });
+
+        mangaList.find({ ref: 'editMangaEntryDialog' }).vm.$emit('closed');
+
+        expect(mangaList.find(EditMangaEntries).exists()).toBeFalsy();
+      });
+
+      it('@cancelEdit - closes edit manga entries dialog', () => {
+        mangaList.setData(
+          { editDialogVisible: true, editDialogBodyVisible: true }
+        );
+
+        mangaList.find(EditMangaEntries).vm.$emit('cancelEdit');
+        expect(mangaList.vm.$data.editDialogVisible).toBeFalsy();
+      });
+
       it('@editComplete - resets selected manga entries and closes modal', () => {
+        mangaList.setData(
+          { editDialogVisible: true, editDialogBodyVisible: true }
+        );
+
         mangaList.find(EditMangaEntries).vm.$emit('editComplete');
 
-        expect(mangaList.vm.$data.editDialogVisible).toBe(false);
+        expect(mangaList.vm.$data.editDialogVisible).toBeFalsy();
         expect(mangaList.vm.$data.selectedEntries).toEqual([]);
       });
+
       it('@editEntry - shows edit manga entry dialog with specific entry', () => {
         mangaList.find(TheMangaList).vm.$emit('editEntry', entry1);
 
-        expect(mangaList.vm.$data.editDialogVisible).toBe(true);
+        expect(mangaList.vm.$data.editDialogVisible).toBeTruthy();
         expect(mangaList.vm.$data.selectedEntries).toEqual([entry1]);
       });
     });


### PR DESCRIPTION
ElementUI destroy-on-close was not reliable, so this commit makes use of it's `open` and `closed` events, to toggle dialog content rendering.

The moment dialog opens, we immediately render contents. But when closing, I want to wait till transition ends and then destroy contents, which is why I have to use
`closed` instead of `close`

I can also remove `closeEditModal` method, as destroying dialog body, means I don't need to manually reset the data anymore