### PR TITLE
Pre-fill edit dialog

### DIFF
--- a/tests/components/manga_entries/ReportMangaEntries.spec.js
+++ b/tests/components/manga_entries/ReportMangaEntries.spec.js
@@ -26,7 +26,7 @@ describe('ReportMangaEntries.vue', () => {
   });
 
   afterEach(() => {
-    expect(postMangaEntriesErrorsMock).toHaveBeenCalledWith(['1'], 0);
+    expect(postMangaEntriesErrorsMock).toHaveBeenCalledWith([1], 0);
   });
 
   describe('if report was successful', () => {

--- a/tests/factories/mangaEntry.js
+++ b/tests/factories/mangaEntry.js
@@ -1,7 +1,7 @@
 import { Factory } from 'rosie';
 
 export default new Factory()
-  .attr('id', '1')
+  .sequence('id')
   .attr('type', 'manga_entry')
   .attr('attributes', {
     title: 'Manga Title',


### PR DESCRIPTION
This component will now prefill information for the list as well as choose correctly, to use either bulk update or normal update endpoint.

![prefill-edit](https://user-images.githubusercontent.com/4270980/75625469-4cddc800-5bb6-11ea-8d3f-eb08b0a9adcc.gif)
