### PR TITLE
Add ability to select new manga source

### DIFF
--- a/src/store/modules/lists.js
+++ b/src/store/modules/lists.js
@@ -1,6 +1,11 @@
 import { Message } from 'element-ui';
 import { secure } from '@/modules/axios';
 
+// Can't access getter inside mutations, hence this has to be a plain function
+export const getEntryIndex = (state, id) => state.entries.findIndex(
+  e => e.id === id
+);
+
 const state = {
   lists: [],
   entries: [],
@@ -41,8 +46,10 @@ const mutations = {
     state.entries.push(data);
   },
   updateEntry(state, data) {
-    const index = state.entries.findIndex(entry => entry.id === data.id);
-    state.entries.splice(index, 1, data);
+    state.entries.splice(getEntryIndex(state, data.id), 1, data);
+  },
+  replaceEntry(state, { currentEntry, newEntry }) {
+    state.entries.splice(getEntryIndex(state, currentEntry.id), 1, newEntry);
   },
   removeEntries(state, entryIDs) {
     state.entries = state.entries.filter(

--- a/tests/components/manga_entries/EditMangaEntries.spec.js
+++ b/tests/components/manga_entries/EditMangaEntries.spec.js
@@ -36,18 +36,35 @@ describe('EditMangaEntries.vue', () => {
   });
 
   describe(':lifecycle', () => {
-    it(':mounted() - prefills manga entry data', async () => {
+    it(':mounted() - prefills manga entry data', () => {
       const editMangaEntries = shallowMount(EditMangaEntries, {
         store,
         localVue,
         propsData: { selectedEntries: [entry1] },
       });
 
-      await flushPromises();
-
       expect(editMangaEntries.vm.$data.listID).toEqual(
         entry1.relationships.manga_list.data.id
       );
+      expect(editMangaEntries.vm.$data.mangaSourceID).toEqual(
+        entry1.manga_source_id
+      );
+    });
+  });
+
+  describe(':props', () => {
+    it(':selectedEntries - shows manga source selector if less than 1 selected', () => {
+      const editMangaEntries = shallowMount(EditMangaEntries, {
+        store,
+        localVue,
+        propsData: { selectedEntries: [entry1] },
+      });
+
+      expect(editMangaEntries.text()).toContain('Manga Source Name');
+
+      editMangaEntries.setProps({ selectedEntries: [entry1, entry2] });
+
+      expect(editMangaEntries.text()).not.toContain('Manga Source Name');
     });
   });
 
@@ -66,7 +83,7 @@ describe('EditMangaEntries.vue', () => {
 
     afterEach(() => {
       expect(updateMangaEntryMock).toHaveBeenCalledWith(
-        1, { manga_list_id: '2' }
+        1, { manga_list_id: '2', manga_source_id: 1 }
       );
     });
 

--- a/tests/factories/mangaEntry.js
+++ b/tests/factories/mangaEntry.js
@@ -2,12 +2,20 @@ import { Factory } from 'rosie';
 
 export default new Factory()
   .sequence('id')
+  .attr('manga_source_id', 1)
   .attr('type', 'manga_entry')
   .attr('attributes', {
     title: 'Manga Title',
     last_chapter_read: '1',
     last_chapter_available: '2',
     last_released_at: '2019-01-01T00:00:00.000Z',
+    available_sources: [
+      {
+        id: 1,
+        manga_series_id: 1,
+        name: 'MangaDex',
+      },
+    ],
   })
   .attr('links', {
     series_url: 'example.url/manga/1',

--- a/tests/store/modules/lists.spec.js
+++ b/tests/store/modules/lists.spec.js
@@ -89,6 +89,25 @@ describe('lists', () => {
       });
     });
 
+    describe('replaceEntry', () => {
+      it('replaces existing manga entry with the one passed', () => {
+        const currentEntry = mangaEntryFactory.build(
+          { id: 1, attributes: { title: 'Manga Title' } }
+        );
+
+        const state = { entries: [currentEntry] };
+
+        const newEntry = mangaEntryFactory.build(
+          { id: 3, attributes: { title: 'Updated Title' } }
+        );
+
+        lists.mutations.replaceEntry(state, { currentEntry, newEntry });
+
+        expect(state.entries.length).toBe(1);
+        expect(state.entries[0]).toEqual(newEntry);
+      });
+    });
+
     describe('removeEntries', () => {
       it('removes a manga entry', () => {
         const entryToStay = mangaEntryFactory.build({ id: '1' });


### PR DESCRIPTION
For now, I will only let people change the manga source on individual entries, but I should be able to make it a bulk action in the future as well

I also can't use `updateEntry` anymore for individual entries, as when changing source, I get a new entry. Instead, I have a new `replaceEntry` mutation, that replaces an existing entry with a new one

![Select manga source](https://user-images.githubusercontent.com/4270980/75627296-deedcc80-5bc6-11ea-8a5d-5c20e7e6b4b8.gif)
