### PR TITLE
Small fixes

### DIFF
--- a/src/components/TheImporters.vue
+++ b/src/components/TheImporters.vue
@@ -38,7 +38,7 @@
           placeholder="https://mangadex.cc/list/3"
           prefix-icon="el-icon-link"
         )
-        p.text-gray-600.text-xs.italic
+        p.text-gray-600.text-xs.italic.break-normal
           | Provide your MangaDex MDList URL. It needs to be all lists link, not
           | specific ones like Reading or Completed.
         el-button.float-right(

--- a/src/components/TheMangaList.vue
+++ b/src/components/TheMangaList.vue
@@ -70,10 +70,12 @@
         template(slot-scope="scope")
           el-button(
             ref="editEntryButton"
+            content="Edit"
             icon="el-icon-edit-outline"
             size="mini"
             @click="editMangaEntry(scope.row)"
             circle
+            v-tippy
           )
           el-button(
             content="Set last read to the latest chapter"


### PR DESCRIPTION
As pointed out by a user, I was missing a tooltip on Edit button on the manga rows, while bulk one had it.

I also fixed text not breaking properly in the MDList Import help text