### PR TITLE
Use manga_list_id instead of relationships

### DIFF
--- a/src/components/manga_entries/EditMangaEntries.vue
+++ b/src/components/manga_entries/EditMangaEntries.vue
@@ -79,9 +79,9 @@
       },
     },
     mounted() {
-      // TODO: Replace with selectedEntries[0].manga_list_id
       // TODO: Remove this when we move to filters
-      this.listID = this.selectedEntries[0].relationships.manga_list.data.id;
+      // TODO: Remove toString() when list serializer returns an int
+      this.listID = this.selectedEntries[0].manga_list_id.toString();
 
       if (!this.isBulkUpdate) {
         this.mangaSourceID = this.selectedEntries[0].manga_source_id;

--- a/src/store/modules/lists.js
+++ b/src/store/modules/lists.js
@@ -14,7 +14,7 @@ const state = {
 
 const getters = {
   getEntriesByListId: state => listID => state.entries.filter(
-    entry => entry.relationships.manga_list.data.id === listID
+    entry => entry.manga_list_id.toString() === listID
   ),
 };
 

--- a/tests/components/manga_entries/EditMangaEntries.spec.js
+++ b/tests/components/manga_entries/EditMangaEntries.spec.js
@@ -44,7 +44,7 @@ describe('EditMangaEntries.vue', () => {
       });
 
       expect(editMangaEntries.vm.$data.listID).toEqual(
-        entry1.relationships.manga_list.data.id
+        entry1.manga_list_id.toString()
       );
       expect(editMangaEntries.vm.$data.mangaSourceID).toEqual(
         entry1.manga_source_id
@@ -89,14 +89,7 @@ describe('EditMangaEntries.vue', () => {
 
     it('uses updateMangaEntry endpoint', async () => {
       editMangaEntries.setData({ listID: '2' });
-      const updatedEntry = mangaEntryFactory.build(
-        {
-          id: 1,
-          relationships: {
-            manga_list: { data: { id: '2', type: 'manga_list' } },
-          },
-        }
-      );
+      const updatedEntry = mangaEntryFactory.build({ id: 1, manga_list_id: 2 });
 
       updateMangaEntryMock.mockResolvedValue(updatedEntry);
 
@@ -114,8 +107,6 @@ describe('EditMangaEntries.vue', () => {
     let updateMangaEntriesMock;
     let updatedMangaEntries;
 
-    const newList = { manga_list: { data: { id: '2', type: 'manga_list' } } };
-
     beforeEach(() => {
       updateMangaEntriesMock = jest.spyOn(api, 'bulkUpdateMangaEntry');
       editMangaEntries = shallowMount(EditMangaEntries, {
@@ -125,8 +116,8 @@ describe('EditMangaEntries.vue', () => {
       });
 
       updatedMangaEntries = [
-        mangaEntryFactory.build({ id: 1, relationships: newList }),
-        mangaEntryFactory.build({ id: 2, relationships: newList }),
+        mangaEntryFactory.build({ id: 1, manga_list_id: 2 }),
+        mangaEntryFactory.build({ id: 2, manga_list_id: 2 }),
       ];
     });
 

--- a/tests/factories/mangaEntry.js
+++ b/tests/factories/mangaEntry.js
@@ -3,7 +3,7 @@ import { Factory } from 'rosie';
 export default new Factory()
   .sequence('id')
   .attr('manga_source_id', 1)
-  .attr('type', 'manga_entry')
+  .attr('manga_list_id', 1)
   .attr('attributes', {
     title: 'Manga Title',
     last_chapter_read: '1',
@@ -21,12 +21,4 @@ export default new Factory()
     series_url: 'example.url/manga/1',
     last_chapter_read_url: 'example.url/chapter/1',
     last_chapter_available_url: 'example.url/chapter/2',
-  })
-  .attr('relationships', {
-    manga_list: {
-      data: {
-        id: '1',
-        type: 'manga_list',
-      },
-    },
   });

--- a/tests/store/modules/lists.spec.js
+++ b/tests/store/modules/lists.spec.js
@@ -12,14 +12,12 @@ describe('lists', () => {
       it('returns entries based on a list id', () => {
         const listID = '1';
         const expectedReturn = mangaEntryFactory.build(
-          { relationships: { manga_list: { data: { id: listID } } } }
+          { manga_list_id: listID }
         );
         const state = {
           entries: [
             expectedReturn,
-            mangaEntryFactory.build(
-              { relationships: { manga_list: { data: { id: '2' } } } }
-            ),
+            mangaEntryFactory.build({ manga_list_id: 2 }),
           ],
         };
 


### PR DESCRIPTION
Now that I am cleaning up the entry serializer, we want to reflect these changes on the client-side