### PR TITLE
Replace old entry when adding one from a new source

### DIFF
--- a/src/components/manga_entries/AddMangaEntry.vue
+++ b/src/components/manga_entries/AddMangaEntry.vue
@@ -18,7 +18,7 @@
 </template>
 
 <script>
-  import { mapMutations } from 'vuex';
+  import { mapMutations, mapGetters } from 'vuex';
   import {
     Message, Button, Input, Loading,
   } from 'element-ui';
@@ -41,15 +41,31 @@
         mangaURL: '',
       };
     },
+    computed: {
+      ...mapGetters('lists', [
+        'findEntryFromIDs',
+      ]),
+    },
     methods: {
       ...mapMutations('lists', [
         'addEntry',
+        'replaceEntry',
       ]),
       mangaDexSearch() {
         const loading = Loading.service({ target: '.add-manga-entry-dialog' });
         addMangaEntry(this.mangaURL, this.currentListID)
           .then((newMangaEntry) => {
-            this.addEntry(newMangaEntry.data);
+            const { data } = newMangaEntry;
+            const currentEntry = this.findEntryFromIDs(
+              data.attributes.tracked_entries.map(e => e.id)
+            );
+
+            if (currentEntry) {
+              this.replaceEntry({ currentEntry, newEntry: data });
+            } else {
+              this.addEntry(newMangaEntry.data);
+            }
+
             this.closeModal(loading);
           })
           .catch((error) => {

--- a/src/store/modules/lists.js
+++ b/src/store/modules/lists.js
@@ -16,6 +16,9 @@ const getters = {
   getEntriesByListId: state => listID => state.entries.filter(
     entry => entry.manga_list_id.toString() === listID
   ),
+  findEntryFromIDs: state => ids => state.entries.find(
+    entry => ids.includes(entry.id)
+  ),
 };
 
 const actions = {

--- a/tests/factories/mangaEntry.js
+++ b/tests/factories/mangaEntry.js
@@ -10,11 +10,11 @@ export default new Factory()
     last_chapter_read: '1',
     last_chapter_available: '2',
     last_released_at: '2019-01-01T00:00:00.000Z',
-    available_sources: [
+    tracked_entries: [
       {
         id: 1,
+        manga_source_id: 1,
         manga_series_id: 1,
-        name: 'MangaDex',
       },
     ],
   })

--- a/tests/store/modules/lists.spec.js
+++ b/tests/store/modules/lists.spec.js
@@ -26,6 +26,19 @@ describe('lists', () => {
         expect(getEntriesByListId(listID)).toEqual([expectedReturn]);
       });
     });
+
+    describe('findEntryFromIDs', () => {
+      it('returns first found entry based on entry IDs being passed', () => {
+        const entry = mangaEntryFactory.build();
+        const state = {
+          entries: [entry, mangaEntryFactory.build()],
+        };
+
+        const findEntryFromIDs = lists.getters.findEntryFromIDs(state);
+
+        expect(findEntryFromIDs([entry.id])).toEqual(entry);
+      });
+    });
   });
 
   describe('mutations', () => {


### PR DESCRIPTION
When manga entry exists and user tries to add the same manga, but from a different source, we want to replace the one currently in the list, as otherwise they will get duplicated until the user refreshes the page.

An example of this can be seen below:
![replace-create](https://user-images.githubusercontent.com/4270980/76126810-0645fe80-5ff8-11ea-9af5-07aa08dd0e35.gif)
