### PR TITLE
Show number of sites tracked

### DIFF
--- a/src/components/TheMangaList.vue
+++ b/src/components/TheMangaList.vue
@@ -28,6 +28,10 @@
             target="_blank"
           )
             | {{ scope.row.attributes.title | sanitize }}
+            .font-normal.text-sm.leading-5.text-gray-500(
+              v-if="scope.row.attributes.tracked_entries.length > 1"
+            )
+              | {{ scope.row.attributes.tracked_entries.length }} sites tracked
       el-table-column(
         prop="attributes.last_chapter_read"
         label="Last Chapter Read"

--- a/tests/components/TheMangaList.spec.js
+++ b/tests/components/TheMangaList.spec.js
@@ -57,16 +57,11 @@ describe('TheMangaList.vue', () => {
 
     it('mutates the state and shows success message', async () => {
       const infoMessageMock = jest.spyOn(Message, 'info');
-      const mangaEntry = mangaEntryFactory.build(
-        {
-          id: '1',
-          attributes: {
-            title: 'Manga Title',
-            last_chapter_read: '2',
-            last_chapter_available: '2',
-          },
-        }
-      );
+      const mangaEntry = mangaEntryFactory.build({ id: 1 });
+
+      mangaEntryFactory.attributes.title = 'Manga Title';
+      mangaEntryFactory.attributes.last_chapter_read = '2';
+      mangaEntryFactory.attributes.last_chapter_available = '2';
 
       updateMangaEntryMock.mockResolvedValue(mangaEntry);
 
@@ -118,13 +113,12 @@ describe('TheMangaList.vue', () => {
 
   describe('when no last chapter is available', () => {
     it('Released at column shows Unknown', async () => {
-      mangaList.setProps({
-        tableData: [
-          mangaEntryFactory.build(
-            { attributes: { title: 'Manga Title', last_released_at: null } }
-          ),
-        ],
-      });
+      const entry = mangaEntryFactory.build();
+
+      entry.attributes.title = 'Manga Title';
+      entry.attributes.last_released_at = null;
+
+      mangaList.setProps({ tableData: [entry] });
 
       await flushPromises();
 
@@ -148,15 +142,31 @@ describe('TheMangaList.vue', () => {
 
   describe(':props', () => {
     it(':tableData - sanitizes manga title to convert special characters', async () => {
-      mangaList.setProps({
-        tableData: [
-          mangaEntryFactory.build({ attributes: { title: '&Uuml;bel Blatt' } }),
-        ],
-      });
+      const entry = mangaEntryFactory.build();
+
+      entry.attributes.title = '&Uuml;bel Blatt';
+
+      mangaList.setProps({ tableData: [entry] });
 
       await flushPromises();
 
       expect(mangaList.find('.el-link--inner').text()).toContain('Übel Blatt');
+    });
+
+    it(':tableData - shows sites tracked if more than one', async () => {
+      const newMangaEntry = mangaEntryFactory.build();
+
+      newMangaEntry.attributes.tracked_entries.push({
+        id: 2,
+        manga_source_id: 2,
+        manga_series_id: 1,
+      });
+
+      mangaList.setProps({ tableData: [newMangaEntry] });
+
+      await flushPromises();
+
+      expect(mangaList.text()).toContain('2 sites tracked');
     });
   });
 });


### PR DESCRIPTION
When the user has entries for multiple sources, but the same series, it will be shown in the UI.

This PR also updates the tests, as Rosie doesn't properly replace nested attributes, instead completely overwrites the object. So I have to manually update object properties, otherwise, I would lose `tracked_entries`

![image](https://user-images.githubusercontent.com/4270980/76129794-4dd08880-6000-11ea-9a15-4a6e74ac1c15.png)
