### PR TITLE
Confirm deletion of multi source entries

### DIFF
--- a/src/components/manga_entries/DeleteMangaEntries.vue
+++ b/src/components/manga_entries/DeleteMangaEntries.vue
@@ -1,0 +1,127 @@
+<template lang="pug">
+  transition(leave-active-class='duration-300')
+    .modal(v-show="visible")
+      transition(
+        enter-active-class='ease-out duration-300'
+        enter-class='opacity-0'
+        enter-to-class='opacity-100'
+        leave-active-class='ease-in duration-200'
+        leave-class='opacity-100'
+        leave-to-class='opacity-0'
+      )
+        .fixed.inset-0.transition-opacity(ref="deleteModalMask" v-show="visible")
+          .absolute.inset-0.bg-gray-500.opacity-75
+      transition(
+        enter-active-class='ease-out duration-300'
+        enter-class='opacity-0 translate-y-4 sm_translate-y-0 sm_scale-95'
+        enter-to-class='opacity-100 translate-y-0 sm_scale-100'
+        leave-active-class='ease-in duration-200'
+        leave-class='opacity-100 translate-y-0 sm_scale-100'
+        leave-to-class='opacity-0 translate-y-4 sm_translate-y-0 sm_scale-95'
+      )
+        .bg-white.rounded-lg.overflow-hidden.shadow-xl.transform.transition-all.sm_max-w-lg.sm_w-full(
+          v-show="visible"
+        )
+          .bg-white.px-4.pt-5.pb-4.sm_p-6.sm_pb-4
+            .sm_flex.sm_items-from
+              .mx-auto.flex-shrink-0.flex.items-center.justify-center.h-12.w-12.rounded-full.bg-red-100.sm_mx-0.sm_h-10.sm_w-10
+                svg.h-6.w-6.text-red-600(
+                  stroke='currentColor'
+                  fill='none'
+                  viewbox='0 0 24 24'
+                )
+                  path(
+                    stroke-linecap='round'
+                    stroke-linejoin='round'
+                    stroke-width='2'
+                    d='M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z'
+                  )
+              .mt-3.text-center.sm_mt-0.sm_ml-4.sm_text-left
+                h3.text-lg.leading-6.font-medium.text-gray-900
+                  | Multiple sites tracked
+                .mt-2
+                  p.text-sm.leading-5.text-gray-500
+                    | Some entries have multiple sites being tracked.
+                    | If you want to delete them all, please proceed. Otherwise,
+                    | use the edit button to switch to a different source.
+          .bg-gray-50.px-4.py-3.sm_px-6.sm_flex.sm_flex-row-reverse
+            span.flex.w-full.rounded-md.shadow-sm.sm_ml-3.sm_w-auto
+              button.base-button-classes.btn-danger(
+                type='button'
+                @click="$emit('confirmDeletion')"
+              )
+                | Delete
+            span.mt-3.flex.w-full.rounded-md.shadow-sm.sm_mt-0.sm_w-auto
+              button.base-button-classes.secondary-btn(
+                type='button'
+                @click="$emit('dialogClosed')"
+              )
+                | Cancel
+</template>
+
+<script>
+  export default {
+    props: {
+      visible: {
+        type: Boolean,
+        default: false,
+      },
+    },
+    mounted() {
+      this.$refs.deleteModalMask.addEventListener('click', (event) => {
+        event.stopPropagation();
+
+        this.$emit('dialogClosed');
+      });
+    },
+  };
+</script>
+
+<style lang="scss" media="screen" scoped>
+  @tailwind base;
+
+  .base-button-classes {
+    @apply inline-flex justify-center w-full rounded-md border px-4 py-2;
+    @apply text-base leading-6 font-medium shadow-sm;
+    @apply transition ease-in-out duration-150;
+
+    &:focus {
+      @apply outline-none;
+    }
+
+    @screen sm {
+      @apply text-sm leading-5;
+    }
+  }
+
+  .btn-danger {
+    @apply border-transparent bg-red-600 text-white;
+
+    &:hover {
+      @apply bg-red-500;
+    }
+
+    &:focus {
+      @apply border-red-700 shadow-outline-red;
+    }
+  }
+
+  .secondary-btn {
+    @apply border-gray-300 bg-white text-gray-700;
+
+    &:hover {
+      @apply text-gray-500;
+    }
+
+    &:focus {
+      @apply border-blue-300 shadow-outline;
+    }
+  }
+
+  .modal {
+    @apply fixed bottom-0 inset-x-0 px-4 pb-4 z-50;
+    @screen sm {
+      @apply flex items-center justify-center inset-0;
+    }
+  }
+</style>

--- a/tests/views/MangaList.spec.js
+++ b/tests/views/MangaList.spec.js
@@ -28,12 +28,9 @@ describe('MangaList.vue', () => {
 
   beforeEach(() => {
     firstMangaList = mangaListFactory.build({ id: '1' });
-    entry1 = mangaEntryFactory.build(
-      { id: 1, attributes: { title: 'Boku no Hero' } }
-    );
-    entry2 = mangaEntryFactory.build(
-      { id: 2, attributes: { title: 'Attack on Titan' } }
-    );
+
+    entry1 = mangaEntryFactory.build({ id: 1 });
+    entry2 = mangaEntryFactory.build({ id: 2 });
 
     store = new Vuex.Store({
       modules: {
@@ -281,6 +278,13 @@ describe('MangaList.vue', () => {
       });
     })
     it(':searchTerm - if present, filters manga entries', () => {
+      const entry1 = mangaEntryFactory.build(
+        { attributes: { title: 'Boku no Hero' } }
+      );
+      const entry2 = mangaEntryFactory.build(
+        { attributes: { title: 'Attack on Titan' } }
+      );
+
       const mangaList = shallowMount(MangaList, {
         store,
         localVue,
@@ -297,7 +301,7 @@ describe('MangaList.vue', () => {
 
       expect(mangaList.vm.filteredEntries).toEqual([entry1, entry2]);
 
-      mangaList.vm.debouncedSearchTerm = 'Boku no';
+      mangaList.setData({ searchTerm: 'Boku no' });
       jest.runAllTimers();
 
       expect(mangaList.vm.filteredEntries).toEqual([entry1]);


### PR DESCRIPTION
If a user tries to delete an entry (or entries), that contain those with multiple sources being tracked, I need to make sure to delete all of them. But the intention is unclear, what a user might want to do, so instead of deleting everything by default, this PR adds a new confirmation modal, when trying to delete such manga. If the user confirms, I delete all entries, otherwise, they can cancel.

![delete-modal](https://user-images.githubusercontent.com/4270980/76150375-c3406580-60a1-11ea-91db-792ec418f3d1.gif)

Modal has also been created using the new design methodology, that I plan to use going forward. Soon all modals will have the same style, which are a lot easier to work with and are fully responsive 

## Full screen
![image](https://user-images.githubusercontent.com/4270980/76150404-069ad400-60a2-11ea-8e6d-c181fafcec2f.png)


## Mobile
![image](https://user-images.githubusercontent.com/4270980/76150391-f1be4080-60a1-11ea-8991-39177b121053.png)
