### PR TITLE
Updated global styles

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -38,6 +38,8 @@
     <link rel="icon" type="image/png" href="<%= BASE_URL %>favicon-32x32.png" sizes="32x32" />
     <link rel="icon" type="image/png" href="<%= BASE_URL %>favicon-16x16.png" sizes="16x16" />
     <link rel="icon" type="image/png" href="<%= BASE_URL %>favicon-128.png" sizes="128x128" />
+    <!-- Styles -->
+    <link rel="stylesheet" href="https://rsms.me/inter/inter.css">
   </head>
   <body>
     <noscript>

--- a/src/components/base_components/BaseCard.vue
+++ b/src/components/base_components/BaseCard.vue
@@ -1,4 +1,4 @@
 <template lang="pug">
-  .w-full.mt-16.rounded.overflow-hidden.shadow-lg.bg-white
+  .w-full.rounded.overflow-hidden.shadow-lg.bg-white
     slot
 </template>

--- a/src/stylesheets/global.scss
+++ b/src/stylesheets/global.scss
@@ -3,18 +3,5 @@
 
 html,
 body {
-  background: -webkit-linear-gradient(
-    180deg,
-    rgb(64, 158, 255),
-    rgb(217, 236, 255)
-  );
-  background: linear-gradient(
-    180deg,
-    rgb(64, 158, 255),
-    rgb(217, 236, 255)
-  );
-  font-family: "Helvetica Neue",Helvetica,"PingFang SC","Hiragino Sans GB","Microsoft YaHei","微软雅黑",Arial,sans-serif;
-  height: 100%;
-  margin: 0;
-  overflow-y: auto;
+  @apply font-sans m-0 overflow-y-auto;
 }

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -1,8 +1,9 @@
 <template lang="pug">
-  #home.h-full.overflow-auto
+  #home.min-h-screen.flex.flex-col.font-sans.bg-blue-300
     navigation-bar
-    transition(name="slide-left" mode="out-in")
-      router-view
+    .flex-grow
+      transition(name="slide-left" mode="out-in")
+        router-view
 </template>
 
 <script>

--- a/src/views/LandingPage.vue
+++ b/src/views/LandingPage.vue
@@ -1,6 +1,6 @@
 <template lang="pug">
   .container.mx-auto.w-full.h-full.flex.flex-col.justify-center.items-center
-    base-card.max-w-lg.text-center.mx-5.md_mx-0
+    base-card.max-w-lg.text-center.mx-5.md_mx-0.my-40
       .p-5
         img.max-w-xs.w-full.inline.logo(src='@/assets/logo.svg' alt="logo")
         .welcome-text.font-size-b.font-line-height-secondary

--- a/src/views/ResetPassword.vue
+++ b/src/views/ResetPassword.vue
@@ -1,7 +1,7 @@
 <template lang="pug">
   .container.mx-auto.w-full.h-full
     .flex.flex-col.h-full.w-full.items-center.justify-center
-      base-card.max-w-sm
+      base-card.max-w-sm.my-56
         .px-6.py-4#reset-pass-card
           p.text-lg.leading-normal.text-gray-600.text-center(
             v-if="tokenValid === null"

--- a/src/views/UserConfirmation.vue
+++ b/src/views/UserConfirmation.vue
@@ -1,7 +1,7 @@
 <template lang="pug">
   .container.mx-auto.w-full.h-full
     .flex.flex-col.h-full.w-full.items-center.justify-center
-      base-card.max-w-sm
+      base-card.max-w-sm.my-56
         .px-6.py-4#user-confirmation-card
           p.text-lg.leading-normal.text-gray-600.text-center(
             v-if="tokenValid === null"

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,3 +1,5 @@
+const defaultTheme = require('tailwindcss/defaultTheme');
+
 module.exports = {
   important: true,
   separator: '_',
@@ -15,6 +17,9 @@ module.exports = {
     extend: {
       margin: {
         '10px': '0.65rem',
+      },
+      fontFamily: {
+        sans: ['Inter var', ...defaultTheme.fontFamily.sans],
       },
     },
   },

--- a/tests/views/__snapshots__/LandingPage.spec.js.snap
+++ b/tests/views/__snapshots__/LandingPage.spec.js.snap
@@ -5,7 +5,7 @@ exports[`LandingPage.vue renders the page 1`] = `
   class="container mx-auto w-full h-full flex flex-col justify-center items-center"
 >
   <base-card-stub
-    class="max-w-lg text-center mx-5 md_mx-0"
+    class="max-w-lg text-center mx-5 md_mx-0 my-40"
   >
     <div
       class="p-5"


### PR DESCRIPTION
This updates default styles in preparation of the new page elements

- Update default fonts to use Inter fonts
- Update global styles to only retain the minimum required
- Set new background from the body, using tailwind css blue
- Remove default margin on `BaseCard` and instead apply margins manually where cards are used
- Set a new responsive layout 