### PR TITLE
Add base button

### DIFF
--- a/src/components/TheImporters.vue
+++ b/src/components/TheImporters.vue
@@ -41,18 +41,18 @@
         p.text-gray-600.text-xs.italic.break-normal
           | Provide your MangaDex MDList URL. It needs to be all lists link, not
           | specific ones like Reading or Completed.
-        el-button.float-right(
-          ref="importMangaDexButton"
-          type="primary"
-          @click="importMangaDex"
-          :disabled="!validUrl"
-        )
-          | Import
+        span.flex.w-full.rounded-md.shadow-sm.sm_w-auto
+          base-button(
+            ref="importMangaDexButton"
+            @click="importMangaDex"
+            :disabled="!validUrl"
+          )
+            | Import
 </template>
 
 <script>
   import {
-    Tabs, TabPane, Input, Link, Upload, Button, Message, Loading,
+    Tabs, TabPane, Input, Link, Upload, Message, Loading,
   } from 'element-ui';
 
   import { secure } from '@/modules/axios';
@@ -69,7 +69,6 @@
       'el-upload': Upload,
       'el-tabs': Tabs,
       'el-tab-pane': TabPane,
-      'el-button': Button,
     },
     data() {
       return {

--- a/src/components/TheResetPassword.vue
+++ b/src/components/TheResetPassword.vue
@@ -24,11 +24,8 @@
           prefix-icon="el-icon-message"
         )
       el-form-item.mb-0
-        el-button.w-full(
-          ref='resetPasswordSubmit'
-          type='primary'
-          @click='submitForm'
-        ) Reset Password
+        base-button(ref='resetPasswordSubmit' @click='submitForm')
+          | Reset Password
       .text-center
         el-divider.my-4
         span
@@ -43,7 +40,7 @@
 
 <script>
   import {
-    Form, FormItem, Button, Input, Link, Message, Loading, Divider,
+    Form, FormItem, Input, Link, Message, Loading, Divider,
   } from 'element-ui';
 
   import { plain } from '@/modules/axios';
@@ -53,7 +50,6 @@
       'el-form': Form,
       'el-form-item': FormItem,
       'el-input': Input,
-      'el-button': Button,
       'el-link': Link,
       'el-divider': Divider,
     },

--- a/src/components/TheSignIn.vue
+++ b/src/components/TheSignIn.vue
@@ -23,11 +23,7 @@
       )
     el-form-item.mb-0
       el-checkbox(v-model="remembered") Remember Me (2 months)
-      el-button.w-full(
-        ref='signInSubmit'
-        type='primary'
-        @click='submitForm'
-      ) Sign In
+      base-button(ref='signInSubmit' @click='submitForm') Sign In
     .text-center
       el-link.mt-4(
         @click.native="$emit('componentChanged', 'TheResetPassword')"
@@ -48,7 +44,7 @@
 <script>
   import { mapActions, mapGetters } from 'vuex';
   import {
-    Form, FormItem, Button, Input, Checkbox, Link, Divider,
+    Form, FormItem, Input, Checkbox, Link, Divider,
   } from 'element-ui';
 
   export default {
@@ -56,7 +52,6 @@
       'el-form': Form,
       'el-form-item': FormItem,
       'el-input': Input,
-      'el-button': Button,
       'el-checkbox': Checkbox,
       'el-link': Link,
       'el-divider': Divider,

--- a/src/components/TheSignUp.vue
+++ b/src/components/TheSignUp.vue
@@ -38,11 +38,7 @@
           @keyup.enter.native='signUp(user)'
         )
       el-form-item
-        el-button.w-full(
-          ref='signUpSubmit'
-          type='primary'
-          @click='submitForm'
-        ) Register
+        base-button(ref='signUpSubmit' @click='submitForm') Register
       .text-center
         el-divider.my-4
         span
@@ -58,7 +54,7 @@
 <script>
   import { mapGetters } from 'vuex';
   import {
-    Form, FormItem, Button, Input, Loading, Message, Divider, Link,
+    Form, FormItem, Input, Loading, Message, Divider, Link,
   } from 'element-ui';
 
   import { plain } from '@/modules/axios';
@@ -68,7 +64,6 @@
       'el-form': Form,
       'el-form-item': FormItem,
       'el-input': Input,
-      'el-button': Button,
       'el-divider': Divider,
       'el-link': Link,
     },

--- a/src/components/base_components/BaseButton.vue
+++ b/src/components/base_components/BaseButton.vue
@@ -1,0 +1,131 @@
+<template lang="pug">
+  button.btn(
+    type='button'
+    :class='classes'
+    :disabled='disabled'
+    @click="$emit('click')"
+  )
+    slot
+</template>
+
+<script>
+  export default {
+    props: {
+      type: {
+        type: String,
+        default: 'primary',
+      },
+      disabled: {
+        type: Boolean,
+        default: false,
+      },
+    },
+    computed: {
+      classes() {
+        return {
+          'btn-primary': this.type === 'primary',
+          'btn-success': this.type === 'success',
+          'btn-secondary': this.type === 'secondary',
+          'btn-info': this.type === 'info',
+          'btn-warn': this.type === 'warning',
+          'btn-danger': this.type === 'danger',
+          disabled: this.disabled,
+        };
+      },
+    },
+  };
+</script>
+
+<style lang="scss" scoped>
+  @tailwind base;
+
+  .btn {
+    @apply inline-flex justify-center w-full rounded-md border px-4 py-2;
+    @apply items-center text-base leading-6 font-medium shadow-sm;
+    @apply transition ease-in-out duration-150;
+
+    &:focus {
+      @apply outline-none;
+    }
+
+    @screen sm {
+      @apply text-sm leading-5;
+    }
+  }
+
+  .btn-secondary {
+    @apply border-gray-300 bg-white text-gray-700;
+
+    &:hover {
+      @apply text-gray-500;
+    }
+
+    &:focus {
+      @apply border-blue-300 shadow-outline;
+    }
+  }
+
+  .btn-primary {
+    @apply border-transparent bg-blue-600 text-white;
+
+    &:hover {
+      @apply bg-blue-500;
+    }
+
+    &:focus {
+      @apply border-blue-700 shadow-outline;
+    }
+  }
+
+  .btn-success {
+    @apply border-transparent bg-el-green text-white;
+
+    &:hover {
+      @apply bg-el-green-light;
+    }
+
+    &:focus {
+      @apply border-green-500 shadow-outline;
+    }
+  }
+
+  .btn-info {
+    @apply border-transparent bg-gray-500 text-white;
+
+    &:hover {
+      @apply bg-gray-400;
+    }
+
+    &:focus {
+      @apply border-gray-600 shadow-outline-red;
+    }
+  }
+
+  .btn-warn {
+    @apply border-transparent bg-yellow-400 text-white;
+
+    &:hover {
+      @apply bg-yellow-300;
+    }
+
+    &:focus {
+      @apply border-yellow-500 shadow-outline-red;
+    }
+  }
+
+  .btn-danger {
+    @apply border-transparent bg-red-600 text-white;
+
+    &:hover {
+      @apply bg-red-500;
+    }
+
+    &:focus {
+      @apply border-red-700 shadow-outline-red;
+    }
+  }
+
+  .disabled {
+    @apply opacity-50 cursor-not-allowed;
+  }
+</style>

--- a/src/components/manga_entries/AddMangaEntry.vue
+++ b/src/components/manga_entries/AddMangaEntry.vue
@@ -6,28 +6,26 @@
       placeholder="https://mangadex.org/title/7139/"
       prefix-icon="el-icon-link"
     )
-    .mt-8.-mb-2.text-right
-      el-button(@click="$emit('dialogClosed')") Cancel
-      el-button(
-        ref="addMangaButton"
-        type="primary"
-        @click="mangaDexSearch"
-        :disabled="mangaURL.length === 0"
-      )
-        | Add
+    .mt-8.-mb-2.sm_flex.sm_flex-row-reverse
+      span.sm_ml-3.flex.w-full.rounded-md.shadow-sm.sm_w-auto
+        base-button(
+          ref="addMangaButton"
+          @click="mangaDexSearch"
+          :disabled="mangaURL.length === 0"
+        )
+          | Add
+      span.mt-3.sm_mt-0.flex.w-full.rounded-md.shadow-sm.sm_w-auto
+        base-button(type="secondary" @click="$emit('dialogClosed')") Cancel
 </template>
 
 <script>
   import { mapMutations, mapGetters } from 'vuex';
-  import {
-    Message, Button, Input, Loading,
-  } from 'element-ui';
+  import { Message, Input, Loading } from 'element-ui';
   import { addMangaEntry } from '@/services/api';
 
   export default {
     name: 'AddMangaEntry',
     components: {
-      'el-button': Button,
       'el-input': Input,
     },
     props: {

--- a/src/components/manga_entries/DeleteMangaEntries.vue
+++ b/src/components/manga_entries/DeleteMangaEntries.vue
@@ -46,16 +46,10 @@
                     | use the edit button to switch to a different source.
           .bg-gray-50.px-4.py-3.sm_px-6.sm_flex.sm_flex-row-reverse
             span.flex.w-full.rounded-md.shadow-sm.sm_ml-3.sm_w-auto
-              button.base-button-classes.btn-danger(
-                type='button'
-                @click="$emit('confirmDeletion')"
-              )
+              base-button(type="danger" @click="$emit('confirmDeletion')")
                 | Delete
             span.mt-3.flex.w-full.rounded-md.shadow-sm.sm_mt-0.sm_w-auto
-              button.base-button-classes.secondary-btn(
-                type='button'
-                @click="$emit('dialogClosed')"
-              )
+              base-button(type="secondary" @click="$emit('dialogClosed')")
                 | Cancel
 </template>
 
@@ -79,44 +73,6 @@
 
 <style lang="scss" media="screen" scoped>
   @tailwind base;
-
-  .base-button-classes {
-    @apply inline-flex justify-center w-full rounded-md border px-4 py-2;
-    @apply text-base leading-6 font-medium shadow-sm;
-    @apply transition ease-in-out duration-150;
-
-    &:focus {
-      @apply outline-none;
-    }
-
-    @screen sm {
-      @apply text-sm leading-5;
-    }
-  }
-
-  .btn-danger {
-    @apply border-transparent bg-red-600 text-white;
-
-    &:hover {
-      @apply bg-red-500;
-    }
-
-    &:focus {
-      @apply border-red-700 shadow-outline-red;
-    }
-  }
-
-  .secondary-btn {
-    @apply border-gray-300 bg-white text-gray-700;
-
-    &:hover {
-      @apply text-gray-500;
-    }
-
-    &:focus {
-      @apply border-blue-300 shadow-outline;
-    }
-  }
 
   .modal {
     @apply fixed bottom-0 inset-x-0 px-4 pb-4 z-50;

--- a/src/components/manga_entries/EditMangaEntries.vue
+++ b/src/components/manga_entries/EditMangaEntries.vue
@@ -25,21 +25,22 @@
           :label="source.name"
           :value="source.id"
         )
-    .mt-8.-mb-2.text-right
-      el-button(@click="$emit('cancelEdit')") Cancel
-      el-button(
-        ref="updateEntryButton"
-        type="primary"
-        @click="updateMangaEntries"
-        :disabled="loadingSources"
-      )
-        | Update
+    .mt-8.-mb-2.sm_flex.sm_flex-row-reverse
+      span.sm_ml-3.flex.w-full.rounded-md.shadow-sm.sm_w-auto
+        base-button(
+          ref="updateEntryButton"
+          @click="updateMangaEntries"
+          :disabled="loadingSources"
+        )
+          | Update
+      span.mt-3.sm_mt-0.flex.w-full.rounded-md.shadow-sm.sm_w-auto
+        base-button(type="secondary" @click="$emit('cancelEdit')") Cancel
 </template>
 
 <script>
   import { mapState, mapMutations } from 'vuex';
   import {
-    Message, Loading, Button, Select, Option,
+    Message, Loading, Select, Option,
   } from 'element-ui';
   import { updateMangaEntry, bulkUpdateMangaEntry } from '@/services/api';
   import { getMangaSources } from '@/services/endpoints/MangaSources';
@@ -47,7 +48,6 @@
   export default {
     name: 'EditMangaEntries',
     components: {
-      'el-button': Button,
       'el-select': Select,
       'el-option': Option,
     },

--- a/src/components/manga_entries/ReportMangaEntries.vue
+++ b/src/components/manga_entries/ReportMangaEntries.vue
@@ -18,20 +18,22 @@
       template(v-else)
         | Select this option, if manga titles are duplicated.
         | They will be manually updated so that only a single manga is shown.
-    .mt-8.-mb-2.text-right
-      el-button(@click="$emit('closeDialog')") Cancel
-      el-button(
-        ref="reportEntriesButton"
-        type="danger"
-        @click="report"
-        :disabled="issueInvalid"
-      )
-        | Report
+    .mt-8.-mb-2.sm_flex.sm_flex-row-reverse
+      span.sm_ml-3.flex.w-full.rounded-md.shadow-sm.sm_w-auto
+        base-button(
+          ref="reportEntriesButton"
+          type="danger"
+          @click="report"
+          :disabled="issueInvalid"
+        )
+          | Report
+      span.mt-3.sm_mt-0.flex.w-full.rounded-md.shadow-sm.sm_w-auto
+        base-button(type="secondary" @click="$emit('closeDialog')") Cancel
 </template>
 
 <script>
   import {
-    Dialog, Button, Select, Option, Message, Loading,
+    Dialog, Select, Option, Message, Loading,
   } from 'element-ui';
 
   import {
@@ -44,7 +46,6 @@
       'el-dialog': Dialog,
       'el-select': Select,
       'el-option': Option,
-      'el-button': Button,
     },
     props: {
       selectedEntries: {

--- a/src/views/MangaList.vue
+++ b/src/views/MangaList.vue
@@ -33,9 +33,9 @@
           )
           span.el-input__prefix
             i.el-input__icon.el-icon-search
-      .mx-5.mb-5.max-sm_mx-2
+      .mx-5.mb-5.max-sm_mx-2.max-sm_flex.max-sm_flex-col
         .bulk-actions.inline-block.max-sm_mb-5.max-sm_float-right
-          el-button.sm_shadow-md(
+          el-button.sm_shadow(
             v-show="entriesSelected"
             content="Delete"
             ref="removeSeriesButton"
@@ -46,7 +46,7 @@
             circle
             v-tippy
           )
-          el-button.sm_shadow-md(
+          el-button.sm_shadow(
             v-show="entriesSelected"
             content="Edit"
             ref="editMangaEntriesButton"
@@ -57,7 +57,7 @@
             circle
             v-tippy
           )
-          el-button.sm_shadow-md(
+          el-button.sm_shadow(
             v-show="entriesSelected"
             content="Report manga issues"
             ref="reportMangaEntriesButton"
@@ -68,24 +68,18 @@
             circle
             v-tippy
           )
-        .actions.inline-block.float-right
-          el-button.sm_shadow-md(
-            type="success"
-            size="medium"
-            @click="importDialogVisible = true"
-            round
-          )
-            i.el-icon-upload2.mr-1
-            | Import
-          el-button.sm_shadow-md(
-            ref="openAddMangaModalButton"
-            type="primary"
-            size="medium"
-            @click="dialogVisible = true"
-            round
-          )
-            i.el-icon-plus.mr-1
-            | Add Manga
+        .actions.inline-block.float-right.sm_flex.sm_flex-row-reverse
+          span.sm_ml-3.flex.w-full.rounded-md.shadow-sm.sm_w-auto
+            base-button(
+              ref="openAddMangaModalButton"
+              @click="dialogVisible = true"
+            )
+              i.el-icon-plus.mr-1
+              | Add Manga
+          span.flex.mt-3.sm_mt-0.w-full.rounded-md.shadow-sm.sm_w-auto
+            base-button(type="success" @click="importDialogVisible = true")
+              i.el-icon-upload2.mr-1
+              | Import
       .flex-grow.sm_mx-5.mx-0
         the-manga-list(
           ref='mangaList'

--- a/src/views/ResetPassword.vue
+++ b/src/views/ResetPassword.vue
@@ -37,18 +37,15 @@
                   @keyup.enter.native='submitForm'
                 )
               el-form-item.mb-0
-                el-button.w-full(
-                  ref='resetPasswordSubmit'
-                  type='primary'
-                  @click='submitForm'
-                ) Save Password
+                base-button(ref='resetPasswordSubmit' @click='submitForm')
+                  | Save Password
           p.leading-normal.text-gray-600.text-center(v-else)
             | {{ this.validationError }}
 </template>
 
 <script>
   import {
-    Form, FormItem, Button, Input,
+    Form, FormItem, Input,
   } from 'element-ui';
   import { mapActions, mapGetters } from 'vuex';
 
@@ -59,7 +56,6 @@
       'el-form': Form,
       'el-form-item': FormItem,
       'el-input': Input,
-      'el-button': Button,
     },
     props: {
       resetPasswordToken: {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -23,6 +23,10 @@ module.exports = {
       full: '100%',
     },
     extend: {
+      colors: {
+        'el-green': '#67C23A',
+        'el-green-light': '#85CE61',
+      },
       margin: {
         '10px': '0.65rem',
       },


### PR DESCRIPTION
This is the first PR to introduce a Tailwind UI based button over ElementUI buttons. 

### Future remaining work:
- [ ] Introduce round buttons
- [ ] Replace remaining ElementUI buttons
- [ ] Finalise colour pallet
- [ ] Introduce Storybook

## Buttons

| Primary | Secondary | Info | Warning | Danger |
| --- | --- | --- | --- | --- |
| <img width="96" alt="Screen Shot 2020-03-16 at 17 28 03" src="https://user-images.githubusercontent.com/4270980/76784422-849a6180-67ab-11ea-8666-55e09048b482.png"> | <img width="96" alt="Screen Shot 2020-03-16 at 17 28 27" src="https://user-images.githubusercontent.com/4270980/76784445-90862380-67ab-11ea-930a-510d5eeeaa83.png"> | <img width="96" alt="Screen Shot 2020-03-16 at 17 29 00" src="https://user-images.githubusercontent.com/4270980/76784489-a693e400-67ab-11ea-8a4c-0527c6dd917e.png"> |  <img width="96" alt="Screen Shot 2020-03-16 at 17 33 21" src="https://user-images.githubusercontent.com/4270980/76784832-405b9100-67ac-11ea-9124-f5428b198a93.png"> | <img width="96" alt="Screen Shot 2020-03-16 at 17 32 51" src="https://user-images.githubusercontent.com/4270980/76784794-2de15780-67ac-11ea-9db0-36ac5a17cb8c.png"> |

| Disabled | Full-width (mobile) | Group |
| --- | --- | --- |
| <img width="82" alt="Screen Shot 2020-03-16 at 17 35 35" src="https://user-images.githubusercontent.com/4270980/76785007-90d2ee80-67ac-11ea-9ff5-d7bec86be63c.png"> | <img width="364" alt="Screen Shot 2020-03-16 at 15 45 28" src="https://user-images.githubusercontent.com/4270980/76784277-3e450280-67ab-11ea-97e6-78f99a58b67e.png"> | <img width="219" alt="Screen Shot 2020-03-16 at 17 26 55" src="https://user-images.githubusercontent.com/4270980/76784393-73e9eb80-67ab-11ea-844f-d073dc97a7cc.png"> |
