### PR TITLE
Log exceptions against a user id

### DIFF
--- a/src/packs/main.js
+++ b/src/packs/main.js
@@ -32,6 +32,12 @@ Vue.use(VueAnalytics, {
 });
 
 if (process.env.NODE_ENV === 'production') {
+  let person = {};
+
+  if (store.getters['user/signedIn']) {
+    person = { id: store.state.user.currentUser.user_id };
+  }
+
   Vue.use(Rollbar, {
     accessToken: '24ea50e0bffd4fa9ad42ed86399fa5b6',
     captureUncaught: true,
@@ -46,6 +52,7 @@ if (process.env.NODE_ENV === 'production') {
           guess_uncaught_frames: true,
         },
       },
+      person,
     },
   });
 }


### PR DESCRIPTION
If user is signed in, include that information when logging an exception with Rollbar. This will help me identify specific users that are having issues, so I can reach out if needed for extra information to help debug