### PR TITLE
Trim urls

### DIFF
--- a/src/components/TheImporters.vue
+++ b/src/components/TheImporters.vue
@@ -41,7 +41,7 @@
               | You will receive an email when the series have been imported.
           template(v-else)
             el-input(
-              v-model="importURL"
+              v-model.trim="importURL"
               placeholder="https://mangadex.cc/list/3"
               prefix-icon="el-icon-link"
             )

--- a/src/components/manga_entries/AddMangaEntry.vue
+++ b/src/components/manga_entries/AddMangaEntry.vue
@@ -15,7 +15,7 @@
           input.placeholder-gray-400.focus_placeholder-gray-300(
             aria-label='Manga URL'
             name='manga_url'
-            v-model="mangaURL"
+            v-model.trim="mangaURL"
             placeholder='https://mangadex.org/title/7139/'
           )
     template(slot='actions')


### PR DESCRIPTION
Users could accidently add whitespaces at the start or end of the url, when adding manga or doing MDLIst import. This makes sure urls are trimmed before sent to the API