### PR TITLE
Add manga input focus on modal open

### DIFF
--- a/src/components/manga_entries/AddMangaEntry.vue
+++ b/src/components/manga_entries/AddMangaEntry.vue
@@ -17,7 +17,7 @@
             aria-label='Manga URL'
             name='manga_url'
             v-model.trim="mangaURL"
-            placeholder='https://mangadex.org/title/7139/'
+            placeholder='Manga or chapter URL'
           )
         p.mt-2.text-xs.text-gray-500
           | When using a chapter URL, last read chapter will be pre-populated

--- a/src/components/manga_entries/AddMangaEntry.vue
+++ b/src/components/manga_entries/AddMangaEntry.vue
@@ -13,6 +13,7 @@
           .absolute.inset-y-0.left-0.pl-3.flex.items-center.pointer-events-none
              i.el-icon-link.text-gray-400.sm_text-sm.sm_leading-5
           input#email.form-input.block.w-full.pl-10.sm_text-sm.sm_leading-5(
+            ref="manga_url"
             aria-label='Manga URL'
             name='manga_url'
             v-model.trim="mangaURL"
@@ -59,6 +60,13 @@
       ...mapGetters('lists', [
         'findEntryFromIDs',
       ]),
+    },
+    watch: {
+      visible(val) {
+        if (val) {
+          this.$nextTick(() => { this.$refs.manga_url.focus(); });
+        }
+      },
     },
     methods: {
       ...mapMutations('lists', [


### PR DESCRIPTION
Small QoL improvement: When Add Manga modal opens, automatically focus the input field. 

This PR also updated the placeholder text to be less confusing (some thought only MangaDex was supported due to the placeholder)