### PR TITLE
Fix signup set current user and update endpoints

### DIFF
--- a/src/services/endpoints/auth/confirmations.js
+++ b/src/services/endpoints/auth/confirmations.js
@@ -1,0 +1,8 @@
+import { plain } from '@/modules/axios';
+
+/* eslint-disable import/prefer-default-export */
+export const show = (confirmationToken) => plain
+  .get('/auth/confirmations', { params: { confirmation_token: confirmationToken } })
+  .then((request) => request)
+  .catch((request) => request.response);
+/* eslint-enable import/prefer-default-export */

--- a/src/services/endpoints/auth/passwords.js
+++ b/src/services/endpoints/auth/passwords.js
@@ -1,0 +1,18 @@
+import { plain } from '@/modules/axios';
+
+const baseURL = '/auth/passwords';
+
+export const create = (email) => plain
+  .post(baseURL, { email })
+  .then((request) => request)
+  .catch((request) => request.response);
+
+export const update = (user, resetPasswordToken) => plain
+  .put(baseURL, { user, reset_password_token: resetPasswordToken })
+  .then((request) => request)
+  .catch((request) => request.response);
+
+export const edit = (resetPasswordToken) => plain
+  .get(`${baseURL}/edit`, { params: { reset_password_token: resetPasswordToken } })
+  .then((request) => request)
+  .catch((request) => request.response);

--- a/src/store/modules/user.js
+++ b/src/store/modules/user.js
@@ -43,21 +43,6 @@ const actions = {
         }
       });
   },
-  updatePassword({ commit }, { resetPasswordToken, user }) {
-    const payload = { user, reset_password_token: resetPasswordToken };
-
-    return plain.put('/auth/passwords/', payload)
-      .then((response) => {
-        commit('setCurrentUser', { user_id: response.data.user_id });
-        localStorage.access = response.data.access;
-      })
-      .catch((request) => {
-        Message.error({
-          dangerouslyUseHTMLString: true,
-          message: request.response.data,
-        });
-      });
-  },
 };
 
 const mutations = {

--- a/tests/services/endpoints/auth/confirmations.spec.js
+++ b/tests/services/endpoints/auth/confirmations.spec.js
@@ -1,0 +1,35 @@
+import axios from 'axios';
+import * as resource from '@/services/endpoints/auth/confirmations';
+
+describe('confirmations', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('show()', () => {
+    let showSpy;
+
+    beforeEach(() => {
+      showSpy = jest.spyOn(axios, 'get');
+    });
+
+    it('makes a request to the resource and returns request', async () => {
+      axios.get.mockResolvedValue({ status: 200 });
+
+      const successful = await resource.show('token');
+
+      expect(successful.status).toBe(200);
+      expect(showSpy).toHaveBeenCalledWith(
+        '/auth/confirmations', { params: { confirmation_token: 'token' } }
+      );
+    });
+
+    it('makes a request to the resource and returns response if failed', async () => {
+      axios.get.mockRejectedValue({ response: { status: 500 } });
+
+      const successful = await resource.show('');
+
+      expect(successful.status).toBe(500);
+    });
+  });
+});

--- a/tests/services/endpoints/auth/passwords.spec.js
+++ b/tests/services/endpoints/auth/passwords.spec.js
@@ -1,0 +1,91 @@
+import axios from 'axios';
+import * as resource from '@/services/endpoints/auth/passwords';
+
+describe('confirmations', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('create()', () => {
+    let createSpy;
+
+    beforeEach(() => {
+      createSpy = jest.spyOn(axios, 'post');
+    });
+
+    it('makes a request to the resource and returns request', async () => {
+      createSpy.mockResolvedValue({ status: 200 });
+
+      const successful = await resource.create('user1@example.com');
+
+      expect(successful.status).toBe(200);
+      expect(createSpy).toHaveBeenCalledWith(
+        '/auth/passwords', { email: 'user1@example.com' }
+      );
+    });
+
+    it('makes a request to the resource and returns response if failed', async () => {
+      createSpy.mockRejectedValue({ response: { status: 500 } });
+
+      const successful = await resource.create('');
+
+      expect(successful.status).toBe(500);
+    });
+  });
+
+  describe('update()', () => {
+    let user;
+    let updateSpy;
+
+    beforeEach(() => {
+      updateSpy = jest.spyOn(axios, 'put');
+      user = { id: 1 };
+    });
+
+    it('makes a request to the resource and returns request', async () => {
+      updateSpy.mockResolvedValue({ status: 200 });
+
+      const successful = await resource.update(user, 'token');
+
+      expect(successful.status).toBe(200);
+      expect(updateSpy).toHaveBeenCalledWith(
+        '/auth/passwords', { user, reset_password_token: 'token' }
+      );
+    });
+
+    it('makes a request to the resource and returns response if failed', async () => {
+      updateSpy.mockRejectedValue({ response: { status: 500 } });
+
+      const successful = await resource.update(user, '');
+
+      expect(successful.status).toBe(500);
+    });
+  });
+
+  describe('edit()', () => {
+    let editSpy;
+
+    beforeEach(() => {
+      editSpy = jest.spyOn(axios, 'get');
+    });
+
+    it('makes a request to the resource and returns request', async () => {
+      editSpy.mockResolvedValue({ status: 200 });
+
+      const successful = await resource.edit('token');
+
+      expect(successful.status).toBe(200);
+      expect(editSpy).toHaveBeenCalledWith(
+        '/auth/passwords/edit', { params: { reset_password_token: 'token' } }
+      );
+    });
+
+    it('makes a request to the resource and returns response if failed', async () => {
+      editSpy.mockRejectedValue({ response: { status: 500 } });
+
+      const successful = await resource.edit('');
+
+      expect(successful.status).toBe(500);
+    });
+  });
+});

--- a/tests/store/modules/user.spec.js
+++ b/tests/store/modules/user.spec.js
@@ -156,54 +156,5 @@ describe('user', () => {
         );
       });
     });
-
-    describe('updatePassword', () => {
-      it('PUTs to passwords endpoint and logs in user on success', async () => {
-        const axiosSpy = jest.spyOn(axios, 'put');
-        const mockData = {
-          resetPasswordToken: 'abcdf',
-          user: { email: 'test@example.com' },
-        };
-        const mockResponse = { access: '123.abc.jwt', user_id: 1 };
-
-        axiosSpy.mockResolvedValue({ status: 200, data: mockResponse });
-
-        user.actions.updatePassword({ commit }, mockData);
-
-        await flushPromises();
-
-        expect(axiosSpy).toHaveBeenCalledWith(
-          '/auth/passwords/',
-          {
-            user: mockData.user,
-            reset_password_token: mockData.resetPasswordToken,
-          },
-        );
-        expect(commit).toHaveBeenCalledWith(
-          'setCurrentUser', { user_id: mockResponse.user_id }
-        );
-      });
-
-      it('shows server-side errors if request failed', async () => {
-        const axiosSpy        = jest.spyOn(axios, 'put');
-        const errorMessageSpy = jest.spyOn(Message, 'error');
-
-        const mockResponse = { response: { data: 'Token expired' } };
-        const mockData = {
-          resetPasswordToken: 'abcdf',
-          user: { email: 'test@example.com' },
-        };
-
-        axiosSpy.mockRejectedValue(mockResponse);
-
-        user.actions.updatePassword({ commit }, mockData);
-
-        await flushPromises();
-
-        expect(commit).not.toHaveBeenCalledWith('setCurrentUser');
-        // TODO: Check that we actually called it with server-side errors
-        expect(errorMessageSpy).toBeCalled();
-      });
-    });
   });
 });

--- a/tests/views/UserConfirmation.spec.js
+++ b/tests/views/UserConfirmation.spec.js
@@ -1,17 +1,20 @@
 import Vuex from 'vuex';
-import axios from 'axios';
+import VueRouter from 'vue-router';
 import flushPromises from 'flush-promises';
 
 import UserConfirmation from '@/views/UserConfirmation.vue';
+import * as resource from '@/services/endpoints/auth/confirmations';
 
 import user from '@/store/modules/user';
 
 const localVue = createLocalVue();
 
 localVue.use(Vuex);
+localVue.use(VueRouter);
 
 describe('UserConfirmation.vue', () => {
-  let userConfirmation;
+  const mutations = { setCurrentUser: jest.fn() };
+
   let store;
 
   beforeEach(() => {
@@ -21,37 +24,65 @@ describe('UserConfirmation.vue', () => {
           namespaced: true,
           state: user.state,
           getters: user.getters,
+          mutations,
         },
-      },
-    });
-
-    userConfirmation = shallowMount(UserConfirmation, {
-      store,
-      localVue,
-      propsData: {
-        confirmationToken: 'token',
       },
     });
   });
 
   describe('when visiting the page', () => {
-    it('shows token is validating message if validating token', async () => {
+    let confirmationsSpy;
+
+    beforeEach(() => {
+      confirmationsSpy = jest.spyOn(resource, 'show');
+    });
+
+    it('shows token is validating message', () => {
+      const userConfirmation = shallowMount(UserConfirmation, {
+        store,
+        localVue,
+        propsData: {
+          confirmationToken: 'token',
+        },
+      });
+
       expect(userConfirmation.text()).toContain('Checking token validity');
     });
 
-    describe('when token is invalid', () => {
-      let axiosSpy;
+    describe('when token is valid', () => {
+      it('sets current user and redirects to manga list', async () => {
+        const user = { user_id: 1, email: 'test1@example.com' };
+        const router = new VueRouter({
+          routes: [{ path: '/manga-list', name: 'manga-list' }],
+        });
 
-      beforeEach(() => {
-        axiosSpy = jest.spyOn(axios, 'get');
+        confirmationsSpy.mockResolvedValue({ status: 200, data: user });
+
+        shallowMount(UserConfirmation, {
+          store,
+          router,
+          localVue,
+          propsData: {
+            confirmationToken: 'token',
+          },
+        });
+
+        await flushPromises();
+
+        expect(router.currentRoute.name).toBe('manga-list');
+        expect(mutations.setCurrentUser).toHaveBeenCalledWith(
+          { currentUser: null }, user
+        );
       });
+    });
 
+    describe('when token is invalid', () => {
       it('shows token not valid validation error', async () => {
-        axiosSpy.mockRejectedValue(
-          { response: { data: { error: 'Token not found' } } }
+        confirmationsSpy.mockResolvedValue(
+          { data: { error: 'Token not found' } }
         );
 
-        userConfirmation = shallowMount(UserConfirmation, {
+        const userConfirmation = shallowMount(UserConfirmation, {
           store,
           localVue,
           propsData: {
@@ -67,11 +98,9 @@ describe('UserConfirmation.vue', () => {
       it('shows generic validation error', async () => {
         const error = 'Something went wrong, try again later or contact hi@kenmei.co';
 
-        axiosSpy.mockRejectedValue(
-          { response: { data: { error: 'Unexpected' } } }
-        );
+        confirmationsSpy.mockResolvedValue({ data: { error: 'Unexpected' } });
 
-        userConfirmation = shallowMount(UserConfirmation, {
+        const userConfirmation = shallowMount(UserConfirmation, {
           store,
           localVue,
           propsData: {


### PR DESCRIPTION
[Ticket →](https://www.meistertask.com/app/task/2MIN2b7c/fix-not-setting-user-email-on-registration)

This PR goal was to fix not setting current user email on password reset or sign up, which I've done. 

But most work ended up going into refactoring how that is done, by extracting confirmation and password endpoints into their respective services. As I result, I could clean up the code, improve code coverage and have more stability all around