### PR TITLE
Add action completed base component

### DIFF
--- a/src/components/TheImporters.vue
+++ b/src/components/TheImporters.vue
@@ -6,55 +6,52 @@
     @dialogClosed="$emit('closeDialog')"
   )
     template(slot='body')
-      el-tabs.w-full(v-model="activeTab" stretch)
+      base-action-completed(
+        v-if="mangaDexImportInitiated || trackrMoeimportInitiated"
+        header="Import started"
+        text="You will receive an email when your manga list have been imported."
+        buttonText="Go back to dashboard"
+        @completeAction="$emit('closeDialog')"
+      )
+      el-tabs.w-full(v-else v-model="activeTab" stretch)
         el-tab-pane(label="Trakr.moe" name="trackrMoe")
-          template(v-if="trackrMoeimportInitiated")
-            p.leading-normal.text-gray-600.text-center.break-normal
-              | Your Trackr.moe import has started. You will receive an email
-              | when the series have been imported.
-          template(v-else)
-            el-upload(
-              ref="upload"
-              action=""
-              :http-request="processUpload"
-              :multiple="false"
-              :show-file-list="false"
-              accept="application/json"
-              drag
-              )
-              i.el-icon-upload
-              .el-upload__text
-                | Drop file here or click to upload
-              .el-upload__tip(slot="tip")
-                | You can download your Trackr.moe list
-                |
-                el-link.align-baseline.text-xs(
-                  href="https://trackr.moe/user/options"
-                  :underline="false"
-                  target="_blank"
-                )
-                  | here
-        el-tab-pane(label="MangaDex" name="mangaDex")
-          template(v-if="mangaDexImportInitiated")
-            p.leading-normal.text-gray-600.text-center.break-normal
-              | Your MangaDex MDList import has started.
-              | You will receive an email when the series have been imported.
-          template(v-else)
-            el-input(
-              v-model.trim="importURL"
-              placeholder="https://mangadex.cc/list/3"
-              prefix-icon="el-icon-link"
+          el-upload(
+            ref="upload"
+            action=""
+            :http-request="processUpload"
+            :multiple="false"
+            :show-file-list="false"
+            accept="application/json"
+            drag
             )
-            p.text-xs.leading-5.text-gray-500
-              | Provide your MangaDex MDList URL. It needs to be all lists link,
-              | not specific ones like Reading or Completed.
-            span.flex.w-full.rounded-md.shadow-sm.sm_w-auto
-              base-button(
-                ref="importMangaDexButton"
-                @click="importMangaDex"
-                :disabled="!validUrl"
+            i.el-icon-upload
+            .el-upload__text
+              | Drop file here or click to upload
+            .el-upload__tip(slot="tip")
+              | You can download your Trackr.moe list
+              |
+              el-link.align-baseline.text-xs(
+                href="https://trackr.moe/user/options"
+                :underline="false"
+                target="_blank"
               )
-                | Import
+                | here
+        el-tab-pane(label="MangaDex" name="mangaDex")
+          el-input(
+            v-model.trim="importURL"
+            placeholder="https://mangadex.cc/list/3"
+            prefix-icon="el-icon-link"
+          )
+          p.text-xs.leading-5.text-gray-500
+            | Provide your MangaDex MDList URL. It needs to be all lists link,
+            | not specific ones like Reading or Completed.
+          span.flex.w-full.rounded-md.shadow-sm.sm_w-auto
+            base-button(
+              ref="importMangaDexButton"
+              @click="importMangaDex"
+              :disabled="!validUrl"
+            )
+              | Import
 </template>
 
 <script>

--- a/src/components/TheResetPassword.vue
+++ b/src/components/TheResetPassword.vue
@@ -6,11 +6,12 @@
     label-position='top'
   )
     template(v-if="resetInitiated")
-      p.leading-normal.text-gray-600.text-center.break-normal
-        | Check your
-        |
-        strong {{ user.email }}
-        |  inbox for instructions from us on how to reset your password
+      base-action-completed(
+        header="Password reset completed"
+        text="Check your inbox for instructions from us on how to reset your password"
+        buttonText="Close"
+        @completeAction="$emit('signOnFinished')"
+      )
     template(v-else)
       el-form-item.mb-6(prop='email')
         p.leading-normal.text-gray-600.mt-0

--- a/src/components/TheSignUp.vue
+++ b/src/components/TheSignUp.vue
@@ -6,11 +6,12 @@
     label-position='top'
   )
     template(v-if="confirmationInitiated")
-      p.leading-normal.text-gray-600.text-center.break-normal
-        | Check your
-        |
-        strong {{ user.email }}
-        |  inbox for instructions from us on how to verify your account
+      base-action-completed(
+        header="Signed up successfully"
+        text="Check your inbox for instructions from us on how to verify your account"
+        buttonText="Close"
+        @completeAction="$emit('signOnFinished')"
+      )
     template(v-else)
       el-form-item(prop='email')
         el-input(

--- a/src/components/base_components/BaseActionCompleted.vue
+++ b/src/components/base_components/BaseActionCompleted.vue
@@ -1,0 +1,45 @@
+<template lang="pug">
+  #action-completed
+    div
+      .mx-auto.flex.items-center.justify-center.h-12.w-12.rounded-full.bg-green-100
+        svg.h-6.w-6.text-green-600.stroke-current(
+          fill='none'
+          viewbox='0 0 24 24'
+        )
+          path(
+            stroke-linecap='round'
+            stroke-linejoin='round'
+            stroke-width='2' d='M5 13l4 4L19 7'
+          )
+      .mt-3.text-center.sm_mt-5
+        h3.text-lg.leading-6.font-medium.text-gray-900(v-text="header")
+        .mt-2
+          p.text-sm.leading-5.text-gray-500(v-text="text")
+    .mt-5.sm_mt-6
+      span.flex.w-full.rounded-md.shadow-sm
+        base-button(@click="$emit('completeAction')")
+          | {{ this.buttonText }}
+</template>
+
+<script>
+  export default {
+    props: {
+      header: {
+        type: String,
+        required: true,
+      },
+      text: {
+        type: String,
+        required: true,
+      },
+      buttonText: {
+        type: String,
+        required: true,
+      },
+    },
+  };
+</script>
+
+<style lang="scss" scoped>
+  @tailwind base;
+</style>


### PR DESCRIPTION
This small improvement brings a new base component, for when an action has been completed. Currently, it uses a success SVG, but this will be updated to use any SVG in the future.

| Reset Password | Sign Up | Import completed |
| --- | --- | --- |
| ![Screen Shot 2020-04-11 at 11 17 29](https://user-images.githubusercontent.com/4270980/79041375-4431d600-7be7-11ea-9e3d-eb970c297c45.png) | ![Screen Shot 2020-04-11 at 11 17 37](https://user-images.githubusercontent.com/4270980/79041376-4431d600-7be7-11ea-8784-04423759c7da.png) | ![Screen Shot 2020-04-11 at 11 17 11](https://user-images.githubusercontent.com/4270980/79041374-4300a900-7be7-11ea-80e0-6b08e9249b90.png) |
