### PR TITLE
Apply preflight globally

### DIFF
--- a/src/components/TheImporters.vue
+++ b/src/components/TheImporters.vue
@@ -42,7 +42,7 @@
             placeholder="https://mangadex.cc/list/3"
             prefix-icon="el-icon-link"
           )
-          p.text-xs.leading-5.text-gray-500
+          p.text-xs.leading-5.text-gray-500.my-3
             | Provide your MangaDex MDList URL. It needs to be all lists link,
             | not specific ones like Reading or Completed.
           span.flex.w-full.rounded-md.shadow-sm.sm_w-auto

--- a/src/components/TheResetPassword.vue
+++ b/src/components/TheResetPassword.vue
@@ -14,7 +14,7 @@
       )
     template(v-else)
       el-form-item.mb-6(prop='email')
-        p.leading-normal.text-gray-600.mt-0
+        p.leading-normal.text-gray-600.mb-3
           | Enter your email address below
           | and we'll send you a link to reset your password.
         el-input(

--- a/src/components/base_components/BaseActionCompleted.vue
+++ b/src/components/base_components/BaseActionCompleted.vue
@@ -39,7 +39,3 @@
     },
   };
 </script>
-
-<style lang="scss" scoped>
-  @tailwind base;
-</style>

--- a/src/components/base_components/BaseButton.vue
+++ b/src/components/base_components/BaseButton.vue
@@ -37,8 +37,6 @@
 </script>
 
 <style lang="scss" scoped>
-  @tailwind base;
-
   .btn {
     @apply inline-flex justify-center w-full rounded-md border px-4 py-2;
     @apply items-center text-base leading-6 font-medium shadow-sm;

--- a/src/components/base_components/BaseFooter.vue
+++ b/src/components/base_components/BaseFooter.vue
@@ -170,8 +170,6 @@
 </script>
 
 <style lang="scss" media="screen" scoped>
-  @tailwind base;
-
   .socials-with-copyright {
     @apply mt-8 border-t pt-8;
 

--- a/src/components/base_components/BaseHamburgerIcon.vue
+++ b/src/components/base_components/BaseHamburgerIcon.vue
@@ -26,7 +26,3 @@
     },
   };
 </script>
-
-<style lang="scss" scoped>
-  @tailwind base;
-</style>

--- a/src/components/base_components/BaseModal.vue
+++ b/src/components/base_components/BaseModal.vue
@@ -92,8 +92,6 @@
 </script>
 
 <style lang="scss" scoped>
-  @tailwind base;
-
   .modal {
     @apply fixed bottom-0 inset-x-0 px-4 pb-4 z-50;
     @screen sm {

--- a/src/components/base_components/BaseNavDark.vue
+++ b/src/components/base_components/BaseNavDark.vue
@@ -158,8 +158,6 @@
 </script>
 
 <style lang="scss" scoped>
-  @tailwind base;
-
   @mixin link-transition {
     @apply transition duration-150 ease-in-out;
   }

--- a/src/components/base_components/BaseNavLight.vue
+++ b/src/components/base_components/BaseNavLight.vue
@@ -160,8 +160,6 @@
 </script>
 
 <style lang="scss" scoped>
-  @tailwind base;
-
   @mixin link-transition {
     @apply transition duration-150 ease-in-out;
   }

--- a/src/components/landing_page/LandingPageCTA.vue
+++ b/src/components/landing_page/LandingPageCTA.vue
@@ -29,8 +29,6 @@
 </script>
 
 <style lang="scss" scoped>
-  @tailwind base;
-
   h2 {
     @apply text-3xl leading-9 font-extrabold tracking-tight text-gray-900;
 

--- a/src/components/landing_page/LandingPageFeatures.vue
+++ b/src/components/landing_page/LandingPageFeatures.vue
@@ -89,8 +89,6 @@
 </script>
 
 <style lang="scss" scoped>
-  @tailwind base;
-
   h3 {
     @apply mt-2 text-3xl leading-8 font-extrabold tracking-tight text-gray-900;
 

--- a/src/components/landing_page/LandingPageHeroSection.vue
+++ b/src/components/landing_page/LandingPageHeroSection.vue
@@ -56,8 +56,6 @@
 </script>
 
 <style lang="scss" scoped>
-  @tailwind base;
-
   .btn-action {
     @apply mt-3 w-full px-6 py-3 border border-transparent text-base leading-6;
     @apply font-medium rounded-md text-white bg-blue-500 shadow-sm transition;

--- a/src/components/landing_page/LandingPageHeroSectionPatternDesktop.vue
+++ b/src/components/landing_page/LandingPageHeroSectionPatternDesktop.vue
@@ -41,7 +41,3 @@
     />
   </svg>
 </template>
-
-<style lang="scss" scoped>
-  @tailwind base;
-</style>

--- a/src/components/landing_page/LandingPageHeroSectionPatternMobile.vue
+++ b/src/components/landing_page/LandingPageHeroSectionPatternMobile.vue
@@ -40,7 +40,3 @@
     />
   </svg>
 </template>
-
-<style lang="scss" scoped>
-  @tailwind base;
-</style>

--- a/src/components/landing_page/LandingPageNavigation.vue
+++ b/src/components/landing_page/LandingPageNavigation.vue
@@ -118,8 +118,6 @@
 </script>
 
 <style lang="scss" scoped>
-  @tailwind base;
-
   @mixin short-transition {
     @apply transition duration-150 ease-in-out;
   }

--- a/src/components/landing_page/LandingPageStats.vue
+++ b/src/components/landing_page/LandingPageStats.vue
@@ -35,8 +35,6 @@
 </template>
 
 <style lang="scss" scoped>
-  @tailwind base;
-
   h2 {
     @apply text-3xl leading-9 font-extrabold text-gray-900;
 

--- a/src/components/manga_entries/AddMangaEntry.vue
+++ b/src/components/manga_entries/AddMangaEntry.vue
@@ -105,8 +105,6 @@
 </script>
 
 <style lang="scss" media="screen" scoped>
-  @tailwind base;
-
   input {
     @apply appearance-none rounded-md block w-full py-2 pl-8;
     @apply border border-gray-300 text-gray-900;

--- a/src/components/manga_entries/DeleteMangaEntries.vue
+++ b/src/components/manga_entries/DeleteMangaEntries.vue
@@ -46,8 +46,6 @@
 </script>
 
 <style lang="scss" media="screen" scoped>
-  @tailwind base;
-
   .warning-icon {
     @apply mx-auto flex-shrink-0 flex items-center justify-center h-12 w-12;
     @apply rounded-full bg-red-100;

--- a/src/stylesheets/global.scss
+++ b/src/stylesheets/global.scss
@@ -6,3 +6,12 @@ html,
 body {
   @apply font-inter m-0 h-full;
 }
+
+// This overwrites loading to be centered, with tailwind preflight enabled
+.el-loading-mask {
+  @apply flex items-center justify-center;
+}
+
+.el-loading-spinner {
+  @apply w-auto mt-0 static;
+}

--- a/src/stylesheets/global.scss
+++ b/src/stylesheets/global.scss
@@ -1,5 +1,6 @@
-@import 'variables';
-@import 'utilities';
+@tailwind base;
+@tailwind variables;
+@tailwind utilities;
 
 html,
 body {

--- a/src/views/Sources.vue
+++ b/src/views/Sources.vue
@@ -55,7 +55,3 @@
     },
   };
 </script>
-
-<style lang="scss" scoped>
-  @tailwind base;
-</style>


### PR DESCRIPTION
This PR applies Tailwind [recommended base classes](https://tailwindcss.com/docs/preflight). These were at odds with Element UI, but with the only a minimum of the components using the library, I was able to do small tweaks letting me apply these styles. 

This will let me replace the remaining components and start adding new ones that rely on preflight