### PR TITLE
Add multi list filtering

### DIFF
--- a/src/components/TheMangaList.vue
+++ b/src/components/TheMangaList.vue
@@ -13,6 +13,7 @@
         width="30"
         align="center"
         sortable="custom"
+        label-class-name="p-0"
       )
         template(slot-scope="scope")
           .new-chapter-dot(v-if="unread(scope.row)")
@@ -37,6 +38,7 @@
         prop="attributes.status"
         label="Manga List"
         width="150"
+        align="center"
       )
         template(slot-scope="scope")
           base-badge(
@@ -46,6 +48,7 @@
       el-table-column(
         prop="attributes.last_chapter_read"
         label="Last Chapter Read"
+        align="center"
       )
         template(v-if='scope.row.attributes' slot-scope="scope")
           el-link.break-normal(
@@ -60,6 +63,7 @@
       el-table-column(
         prop="links.last_chapter_available_url"
         label="Latest Chapter"
+        align="center"
       )
         template(v-if='scope.row.attributes' slot-scope="scope")
           el-link(
@@ -74,6 +78,7 @@
       el-table-column(
         prop="attributes.last_released_at"
         label="Released"
+        align="center"
         sortable="custom"
       )
         template(v-if='scope.row.attributes' slot-scope="scope")

--- a/src/components/TheMangaList.vue
+++ b/src/components/TheMangaList.vue
@@ -20,6 +20,7 @@
         prop="attributes.title"
         label="Title"
         sortable="custom"
+        width="400"
       )
         template(slot-scope="scope")
           el-link.break-normal(

--- a/src/components/TheMangaList.vue
+++ b/src/components/TheMangaList.vue
@@ -34,6 +34,16 @@
             )
               | {{ scope.row.attributes.tracked_entries.length }} sites tracked
       el-table-column(
+        prop="attributes.status"
+        label="Manga List"
+        width="150"
+      )
+        template(slot-scope="scope")
+          base-badge(
+            :text="entryListName(scope.row)"
+            :type="entryType(scope.row)"
+          )
+      el-table-column(
         prop="attributes.last_chapter_read"
         label="Last Chapter Read"
       )
@@ -104,7 +114,7 @@
 </template>
 
 <script>
-  import { mapState, mapMutations } from 'vuex';
+  import { mapState, mapGetters, mapMutations } from 'vuex';
   import {
     Table, TableColumn, Link, Button, Message, Pagination,
   } from 'element-ui';
@@ -150,6 +160,9 @@
       ...mapState('lists', [
         'listsLoading',
       ]),
+      ...mapGetters('lists', [
+        'findListByID',
+      ]),
       currentPageEntries() {
         const page = this.currentPage - 1;
         return this.sortedData.slice(page * 50, (page + 1) * 50);
@@ -168,6 +181,14 @@
       ...mapMutations('lists', [
         'updateEntry',
       ]),
+      entryListName(entry) {
+        return this.findListByID(entry.manga_list_id.toString()).attributes.name;
+      },
+      entryType(entry) {
+        const { status } = entry.attributes;
+
+        return { 1: 'success', 2: 'warning', 5: 'danger' }[status];
+      },
       async setLastRead(entry) {
         this.entryUpdated = entry;
 

--- a/src/components/base_components/BaseBadge.vue
+++ b/src/components/base_components/BaseBadge.vue
@@ -1,0 +1,36 @@
+<template lang="pug">
+  span(v-text="text" :class="classes")
+</template>
+
+<script>
+  export default {
+    props: {
+      text: {
+        type: String,
+        required: true,
+      },
+      type: {
+        type: String,
+        default: 'primary',
+      },
+    },
+    computed: {
+      classes() {
+        return {
+          'bg-blue-100 text-blue-800': this.type === 'primary',
+          'bg-green-100 text-green-800': this.type === 'success',
+          'bg-gray-100 text-gray-800': this.type === 'secondary',
+          'bg-orange-100 text-orange-800': this.type === 'warning',
+          'bg-red-100 text-red-800': this.type === 'danger',
+        };
+      },
+    },
+  };
+</script>
+
+<style lang="scss" scoped>
+  span {
+    @apply inline-flex items-center rounded-full text-xs font-medium leading-4;
+    @apply px-2.5 py-0.5;
+  }
+</style>

--- a/src/components/manga_entries/AddMangaEntry.vue
+++ b/src/components/manga_entries/AddMangaEntry.vue
@@ -6,20 +6,32 @@
     @dialogClosed="closeModal()"
   )
     template(slot='body')
-      .mt-3.text-center.sm_mt-0.sm_text-left.w-full
-        label.block.text-sm.font-medium.leading-5.text-gray-700(for='url')
-          | Manga URL
-        .mt-1.relative.rounded-md.shadow-sm
-          .absolute.inset-y-0.left-0.pl-3.flex.items-center.pointer-events-none
-             i.el-icon-link.text-gray-400.sm_text-sm.sm_leading-5
-          input#email.form-input.block.w-full.pl-10.sm_text-sm.sm_leading-5(
-            aria-label='Manga URL'
-            name='manga_url'
-            v-model.trim="mangaURL"
-            placeholder='https://mangadex.org/title/7139/'
-          )
-        p.mt-2.text-xs.text-gray-500
-          | When using a chapter URL, last read chapter will be pre-populated
+      .flex.flex-col.w-full
+        .mt-3.text-center.sm_mt-0.sm_text-left.w-full
+          label.block.text-sm.font-medium.leading-5.text-gray-700(for='url')
+            | Manga URL
+          .mt-1.relative.rounded-md.shadow-sm
+            .absolute.inset-y-0.left-0.pl-3.flex.items-center.pointer-events-none
+               i.el-icon-link.text-gray-400.sm_text-sm.sm_leading-5
+            input#email.form-input.block.w-full.pl-10.sm_text-sm.sm_leading-5(
+              aria-label='Manga URL'
+              name='manga_url'
+              v-model.trim="mangaURL"
+              placeholder='https://mangadex.org/title/7139/'
+            )
+          p.mt-2.text-xs.text-gray-500
+            | When using a chapter URL, last read chapter will be pre-populated
+        .mt-6.text-center.sm_text-left.w-full
+          label.block.text-sm.leading-5.font-medium.text-gray-700
+            | List Name
+          .mt-1.relative.rounded-md.shadow-sm.w-auto
+            el-select.rounded.w-full(v-model="listID")
+              el-option(
+                v-for="list in lists"
+                :key="list.id"
+                :label="list.attributes.name"
+                :value="list.id"
+              )
     template(slot='actions')
       span.flex.w-full.rounded-md.shadow-sm.sm_ml-3.sm_w-auto
         base-button(
@@ -33,32 +45,41 @@
 </template>
 
 <script>
-  import { mapMutations, mapGetters } from 'vuex';
-  import { Message } from 'element-ui';
+  import { mapState, mapMutations, mapGetters } from 'vuex';
+  import { Message, Select, Option } from 'element-ui';
   import { addMangaEntry } from '@/services/api';
 
   export default {
     name: 'AddMangaEntry',
+    components: {
+      'el-select': Select,
+      'el-option': Option,
+    },
     props: {
       visible: {
         type: Boolean,
         default: false,
       },
-      currentListID: {
-        type: String,
-        required: true,
-      },
     },
     data() {
       return {
         mangaURL: '',
+        listID: '',
         loading: false,
       };
     },
     computed: {
+      ...mapState('lists', [
+        'lists',
+      ]),
       ...mapGetters('lists', [
         'findEntryFromIDs',
       ]),
+    },
+    mounted() {
+      this.listID = this.lists.find(
+        (list) => list.attributes.name === 'Reading'
+      ).id;
     },
     methods: {
       ...mapMutations('lists', [
@@ -68,7 +89,7 @@
       mangaDexSearch() {
         this.loading = true;
 
-        addMangaEntry(this.mangaURL, this.currentListID)
+        addMangaEntry(this.mangaURL, this.listID)
           .then((newMangaEntry) => {
             const { data } = newMangaEntry;
             const currentEntry = this.findEntryFromIDs(

--- a/src/store/modules/lists.js
+++ b/src/store/modules/lists.js
@@ -13,9 +13,11 @@ const state = {
 };
 
 const getters = {
-  getEntriesByListId: (state) => (listID) => state.entries.filter(
-    (entry) => entry.manga_list_id.toString() === listID
+  // TODO: Rename to getEntriesByTagIDs when renaming manga lists to tags
+  getEntriesByListIDs: (state) => (listIDs) => state.entries.filter(
+    (entry) => !listIDs.length || listIDs.includes(entry.manga_list_id.toString())
   ),
+  findListByID: (state) => (id) => state.lists.find((list) => list.id === id),
   findEntryFromIDs: (state) => (ids) => state.entries.find(
     (entry) => ids.includes(entry.id)
   ),

--- a/src/views/MangaList.vue
+++ b/src/views/MangaList.vue
@@ -75,6 +75,7 @@
             base-button(
               ref="addMangaEntryModalButton"
               @click="dialogVisible = true"
+              :disabled="!lists.length"
             )
               i.el-icon-plus.mr-1
               | Add Manga
@@ -94,6 +95,7 @@
         @closeDialog="importDialogVisible = false"
       )
       add-manga-entry(
+        v-if="lists.length"
         ref='addMangaEntryModal'
         :visible="dialogVisible"
         @dialogClosed='dialogVisible = false'
@@ -200,7 +202,7 @@
         let filtered = this.entries;
 
         if (this.selectedListIDs.length) {
-          const taggedEntries = this.getEntriesByTagIDs(this.selectedListIDs);
+          const taggedEntries = this.getEntriesByListIDs(this.selectedListIDs);
 
           filtered = filtered.filter((e) => taggedEntries.includes(e));
         }

--- a/tests/components/TheMangaList.spec.js
+++ b/tests/components/TheMangaList.spec.js
@@ -5,8 +5,9 @@ import flushPromises from 'flush-promises';
 import MangaList from '@/components/TheMangaList.vue';
 import lists from '@/store/modules/lists';
 import * as api from '@/services/api';
-import mangaEntryFactory from '../factories/mangaEntry';
 
+import mangaEntryFactory from '../factories/mangaEntry';
+import mangaListFactory from '../factories/mangaList';
 
 const localVue = createLocalVue();
 
@@ -26,10 +27,16 @@ describe('TheMangaList.vue', () => {
         lists: {
           namespaced: true,
           state: {
-            lists: [],
+            lists: [
+              mangaListFactory.build(),
+              mangaListFactory.build(
+                { id: '2', attributes: { name: 'Completed' } }
+              ),
+            ],
             entries: [mangaEntryFactory.build({ id: '1' })],
           },
           mutations: lists.mutations,
+          getters: lists.getters,
         },
       },
     });
@@ -39,6 +46,22 @@ describe('TheMangaList.vue', () => {
       propsData: {
         tableData: defaultEntries,
       },
+    });
+  });
+
+  describe('when showing entries', () => {
+    it('displays manga list name for each entry', async () => {
+      const entry1 = mangaEntryFactory.build({ id: '1' });
+      const entry2 = mangaEntryFactory.build({ id: '2', manga_list_id: 2 });
+
+      mangaList.setData({ sortedData: [entry1, entry2] });
+
+      await nextTick();
+
+      const rows = mangaList.findAll('.el-table__row');
+
+      expect(rows.at(0).text()).toContain('Reading');
+      expect(rows.at(1).text()).toContain('Completed');
     });
   });
 

--- a/tests/components/manga_entries/AddMangaEntry.spec.js
+++ b/tests/components/manga_entries/AddMangaEntry.spec.js
@@ -13,46 +13,61 @@ const localVue = createLocalVue();
 localVue.use(Vuex);
 
 describe('AddMangaEntry.vue', () => {
-  describe('when adding new MangaDex entry', () => {
-    let store;
-    let addMangaEntry;
+  let store;
+  let addMangaEntry;
 
-    const mangaList = mangaListFactory.build();
+  const mangaList = mangaListFactory.build();
 
-    beforeEach(() => {
-      store = new Vuex.Store({
-        modules: {
-          lists: {
-            namespaced: true,
-            state: {
-              lists: [mangaList],
-              entries: [],
-            },
-            mutations: lists.mutations,
-            getters: lists.getters,
+  beforeEach(() => {
+    store = new Vuex.Store({
+      modules: {
+        lists: {
+          namespaced: true,
+          state: {
+            lists: [mangaList],
+            entries: [],
           },
+          mutations: lists.mutations,
+          getters: lists.getters,
         },
-      });
+      },
+    });
+
+    addMangaEntry = shallowMount(AddMangaEntry, { store, localVue });
+  });
+
+  describe(':lifecycle', () => {
+    it(':mounted() - sets manga list to Reading', () => {
       addMangaEntry = shallowMount(AddMangaEntry, {
         store,
         localVue,
-        data() {
-          return {
-            mangaURL: 'example.url/manga/1',
-          };
-        },
-        propsData: {
-          currentListID: '1',
-        },
+        data() { return { listID: '' }; },
       });
+
+      expect(addMangaEntry.vm.listID).toEqual(mangaList.id);
+    });
+  });
+
+  describe('when adding new MangaDex entry', () => {
+    let addMangaEntrySpy;
+
+    beforeEach(() => {
+      addMangaEntry.setData({ mangaURL: 'example.url/manga/1' });
+
+      addMangaEntrySpy = jest.spyOn(api, 'addMangaEntry');
+    });
+
+    afterEach(() => {
+      expect(addMangaEntrySpy).toHaveBeenCalledWith(
+        'example.url/manga/1', mangaList.id
+      );
     });
 
     describe('when no manga sources are tracked', () => {
       it('adds new Manga entry to the list', async () => {
-        const addMangaEntryMock = jest.spyOn(api, 'addMangaEntry');
-        const mangaEntry        = mangaEntryFactory.build();
+        const mangaEntry = mangaEntryFactory.build();
 
-        addMangaEntryMock.mockResolvedValue({ data: mangaEntry });
+        addMangaEntrySpy.mockResolvedValue({ data: mangaEntry });
 
         addMangaEntry.vm.mangaDexSearch();
 
@@ -68,7 +83,6 @@ describe('AddMangaEntry.vue', () => {
         const oldEntry = mangaEntryFactory.build();
         store.state.lists.entries = [oldEntry];
 
-        const addMangaEntryMock = jest.spyOn(api, 'addMangaEntry');
         const newMangaEntry = mangaEntryFactory.build({
           id: 2,
           manga_source_id: 2,
@@ -90,7 +104,7 @@ describe('AddMangaEntry.vue', () => {
           },
         });
 
-        addMangaEntryMock.mockResolvedValue({ data: newMangaEntry });
+        addMangaEntrySpy.mockResolvedValue({ data: newMangaEntry });
 
         addMangaEntry.vm.mangaDexSearch();
 
@@ -104,10 +118,9 @@ describe('AddMangaEntry.vue', () => {
 
     describe('when receiving 404 status', () => {
       it('shows info message with payload data', async () => {
-        const infoMessageMock   = jest.spyOn(Message, 'info');
-        const addMangaEntryMock = jest.spyOn(api, 'addMangaEntry');
+        const infoMessageMock = jest.spyOn(Message, 'info');
 
-        addMangaEntryMock.mockRejectedValue(
+        addMangaEntrySpy.mockRejectedValue(
           { response: { status: 404, data: 'Manga was not found' } }
         );
 
@@ -120,10 +133,9 @@ describe('AddMangaEntry.vue', () => {
 
     describe('when receiving 406 status', () => {
       it('shows info message with payload data', async () => {
-        const infoMessageMock   = jest.spyOn(Message, 'info');
-        const addMangaEntryMock = jest.spyOn(api, 'addMangaEntry');
+        const infoMessageMock = jest.spyOn(Message, 'info');
 
-        addMangaEntryMock.mockRejectedValue(
+        addMangaEntrySpy.mockRejectedValue(
           { response: { status: 406, data: 'Manga already added' } }
         );
 
@@ -135,10 +147,9 @@ describe('AddMangaEntry.vue', () => {
     });
 
     it('shows error message on unsuccessful API lookup', async () => {
-      const errorMessageMock  = jest.spyOn(Message, 'error');
-      const addMangaEntryMock = jest.spyOn(api, 'addMangaEntry');
+      const errorMessageMock = jest.spyOn(Message, 'error');
 
-      addMangaEntryMock.mockRejectedValue({ response: { status: 500 } });
+      addMangaEntrySpy.mockRejectedValue({ response: { status: 500 } });
 
       addMangaEntry.vm.mangaDexSearch();
 

--- a/tests/factories/mangaEntry.js
+++ b/tests/factories/mangaEntry.js
@@ -7,6 +7,7 @@ export default new Factory()
   .attr('manga_list_id', 1)
   .attr('attributes', {
     title: 'Manga Title',
+    status: 1,
     last_chapter_read: '1',
     last_chapter_available: '2',
     last_released_at: '2019-01-01T00:00:00.000Z',

--- a/tests/store/modules/lists.spec.js
+++ b/tests/store/modules/lists.spec.js
@@ -8,12 +8,10 @@ import mangaListFactory from '../../factories/mangaList';
 
 describe('lists', () => {
   describe('getters', () => {
-    describe('getEntriesByListId', () => {
+    describe('getEntriesByListIDs', () => {
       it('returns entries based on a list id', () => {
-        const listID = '1';
-        const expectedReturn = mangaEntryFactory.build(
-          { manga_list_id: listID }
-        );
+        const listIDs = ['1'];
+        const expectedReturn = mangaEntryFactory.build({ manga_list_id: '1' });
         const state = {
           entries: [
             expectedReturn,
@@ -21,9 +19,9 @@ describe('lists', () => {
           ],
         };
 
-        const getEntriesByListId = lists.getters.getEntriesByListId(state);
+        const getEntriesByListIDs = lists.getters.getEntriesByListIDs(state);
 
-        expect(getEntriesByListId(listID)).toEqual([expectedReturn]);
+        expect(getEntriesByListIDs(listIDs)).toEqual([expectedReturn]);
       });
     });
 
@@ -37,6 +35,17 @@ describe('lists', () => {
         const findEntryFromIDs = lists.getters.findEntryFromIDs(state);
 
         expect(findEntryFromIDs([entry.id])).toEqual(entry);
+      });
+    });
+
+    describe('findListByID', () => {
+      it('returns list based on list ID provided', () => {
+        const list  = mangaListFactory.build({ id: 2 });
+        const state = { lists: [list] };
+
+        const findListByID = lists.getters.findListByID(state);
+
+        expect(findListByID(2)).toEqual(list);
       });
     });
   });


### PR DESCRIPTION
This is the first part of adding the ability to filter by multiple lists (soon to be renamed to tags) as well as prepping the stage for adding the reading status as a separate field and filter option.

This PR brings a couple of new improvements:
1. It is possible to view all manga entries at once, not being limited by looking at only one manga list at a time. This brings ability to search through all entries as well
2. Manga list filter now lets you filter by any and all lists available. You can mix and match them as you want. 
3. I've added a new column to the table, that shows the tag for the list the entry belongs to, as it was not possible to discern otherwise which entry belongs to what.
4. I've added a manual width for title. This was something that has been requested before, but I hesitated as it made mobile users having to scroll. I've realised users already have to scroll anyways, so I decided to do it, as otherwise, with the new column, the title would become even smaller. This is temporary anyways, as I plan to replace the table in the near future.
5. Center columns, except title and actions, to make better use of space

![final-filters](https://user-images.githubusercontent.com/4270980/80923504-1ff78e00-8d7c-11ea-8405-53212286e7f9.gif)

