### PR TITLE
Add ability to filter by status

### DIFF
--- a/src/components/TheMangaList.vue
+++ b/src/components/TheMangaList.vue
@@ -36,13 +36,13 @@
               | {{ scope.row.attributes.tracked_entries.length }} sites tracked
       el-table-column(
         prop="attributes.status"
-        label="Manga List"
+        label="Status"
         width="150"
         align="center"
       )
         template(slot-scope="scope")
           base-badge(
-            :text="entryListName(scope.row)"
+            :text="entryStatusName(scope.row)"
             :type="entryType(scope.row)"
           )
       el-table-column(
@@ -119,7 +119,7 @@
 </template>
 
 <script>
-  import { mapState, mapGetters, mapMutations } from 'vuex';
+  import { mapState, mapMutations } from 'vuex';
   import {
     Table, TableColumn, Link, Button, Message, Pagination,
   } from 'element-ui';
@@ -163,10 +163,8 @@
     },
     computed: {
       ...mapState('lists', [
+        'statuses',
         'listsLoading',
-      ]),
-      ...mapGetters('lists', [
-        'findListByID',
       ]),
       currentPageEntries() {
         const page = this.currentPage - 1;
@@ -186,13 +184,15 @@
       ...mapMutations('lists', [
         'updateEntry',
       ]),
-      entryListName(entry) {
-        return this.findListByID(entry.manga_list_id.toString()).attributes.name;
+      entryStatusName(e) {
+        return this.statuses.find((s) => s.enum === e.attributes.status).name;
       },
       entryType(entry) {
         const { status } = entry.attributes;
 
-        return { 1: 'success', 2: 'warning', 5: 'danger' }[status];
+        return {
+          1: 'success', 2: 'warning', 3: 'warning-light', 5: 'danger'
+        }[status];
       },
       async setLastRead(entry) {
         this.entryUpdated = entry;

--- a/src/components/base_components/BaseBadge.vue
+++ b/src/components/base_components/BaseBadge.vue
@@ -20,6 +20,7 @@
           'bg-blue-100 text-blue-800': this.type === 'primary',
           'bg-green-100 text-green-800': this.type === 'success',
           'bg-gray-100 text-gray-800': this.type === 'secondary',
+          'bg-yellow-100 text-yellow-800': this.type === 'warning-light',
           'bg-orange-100 text-orange-800': this.type === 'warning',
           'bg-red-100 text-red-800': this.type === 'danger',
         };

--- a/src/components/manga_entries/AddMangaEntry.vue
+++ b/src/components/manga_entries/AddMangaEntry.vue
@@ -13,7 +13,7 @@
           .mt-1.relative.rounded-md.shadow-sm
             .absolute.inset-y-0.left-0.pl-3.flex.items-center.pointer-events-none
                i.el-icon-link.text-gray-400.sm_text-sm.sm_leading-5
-            input#email.form-input.block.w-full.pl-10.sm_text-sm.sm_leading-5(
+            input.form-input.block.w-full.pl-10.sm_text-sm.sm_leading-5(
               aria-label='Manga URL'
               name='manga_url'
               v-model.trim="mangaURL"
@@ -23,14 +23,14 @@
             | When using a chapter URL, last read chapter will be pre-populated
         .mt-6.text-center.sm_text-left.w-full
           label.block.text-sm.leading-5.font-medium.text-gray-700
-            | List Name
+            | Status
           .mt-1.relative.rounded-md.shadow-sm.w-auto
-            el-select.rounded.w-full(v-model="listID")
+            el-select.rounded.w-full(v-model="selectedStatus")
               el-option(
-                v-for="list in lists"
-                :key="list.id"
-                :label="list.attributes.name"
-                :value="list.id"
+                v-for="status in statuses"
+                :key="status.enum"
+                :label="status.name"
+                :value="status.enum"
               )
     template(slot='actions')
       span.flex.w-full.rounded-md.shadow-sm.sm_ml-3.sm_w-auto
@@ -64,22 +64,17 @@
     data() {
       return {
         mangaURL: '',
-        listID: '',
+        selectedStatus: 1,
         loading: false,
       };
     },
     computed: {
       ...mapState('lists', [
-        'lists',
+        'statuses',
       ]),
       ...mapGetters('lists', [
         'findEntryFromIDs',
       ]),
-    },
-    mounted() {
-      this.listID = this.lists.find(
-        (list) => list.attributes.name === 'Reading'
-      ).id;
     },
     methods: {
       ...mapMutations('lists', [
@@ -89,7 +84,7 @@
       mangaDexSearch() {
         this.loading = true;
 
-        addMangaEntry(this.mangaURL, this.listID)
+        addMangaEntry(this.mangaURL, this.selectedStatus)
           .then((newMangaEntry) => {
             const { data } = newMangaEntry;
             const currentEntry = this.findEntryFromIDs(

--- a/src/components/manga_entries/EditMangaEntries.vue
+++ b/src/components/manga_entries/EditMangaEntries.vue
@@ -9,17 +9,14 @@
       .flex.flex-col.w-full
         .mt-3.text-center.sm_mt-0.sm_text-left.w-full
           label.block.text-sm.leading-5.font-medium.text-gray-700
-            | List Name
+            | Status
           .mt-1.relative.rounded-md.shadow-sm.w-auto
-            el-select.rounded.w-full.mt-3(
-              v-model="listID"
-              placeholder="Select new list"
-            )
+            el-select.rounded.w-full.mt-3(v-model="selectedStatus")
               el-option(
-                v-for="list in lists"
-                :key="list.id"
-                :label="list.attributes.name"
-                :value="list.id"
+                v-for="status in statuses"
+                :key="status.enum"
+                :label="status.name"
+                :value="status.enum"
               )
         .mt-5.text-center.sm_text-left.w-full(v-if="!isBulkUpdate")
           label.block.text-sm.leading-5.font-medium.text-gray-700
@@ -73,7 +70,7 @@
     },
     data() {
       return {
-        listID: null,
+        selectedStatus: 1,
         mangaSourceID: null,
         availableSources: [],
         loadingSources: false,
@@ -82,7 +79,7 @@
     },
     computed: {
       ...mapState('lists', [
-        'lists',
+        'statuses',
       ]),
       selectedEntry() {
         return this.selectedEntries[0];
@@ -96,12 +93,9 @@
     },
     watch: {
       selectedEntries(entries, oldEntries) {
-        if (entries.length > 0 && entries !== oldEntries) {
-          // TODO: Remove this when we move to filters
-          // TODO: Remove toString() when list serializer returns an int
-          this.listID = this.selectedEntry.manga_list_id.toString();
-
-          if (!this.isBulkUpdate) { this.loadAvailableSources(); }
+        if (entries.length && entries !== oldEntries && !this.isBulkUpdate) {
+          this.loadAvailableSources();
+          this.selectedStatus = this.selectedEntry.attributes.status;
         }
       },
     },
@@ -133,7 +127,7 @@
       },
       async updateMangaEntries() {
         this.loading = true;
-        const params  = { manga_list_id: this.listID };
+        const params  = { status: this.selectedStatus };
 
         if (!this.isBulkUpdate) { params.manga_source_id = this.mangaSourceID; }
 

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -1,11 +1,8 @@
 import { secure } from '@/modules/axios';
 
-export const addMangaEntry = (seriesURL, mangaListID) => secure
+export const addMangaEntry = (seriesURL, status) => secure
   .post('/api/v1/manga_entries/', {
-    manga_entry: {
-      series_url: seriesURL,
-      manga_list_id: mangaListID,
-    },
+    manga_entry: { series_url: seriesURL, status },
   })
   .then((response) => {
     if (response.data.error) { return {}; }

--- a/src/store/modules/lists.js
+++ b/src/store/modules/lists.js
@@ -9,15 +9,25 @@ export const getEntryIndex = (state, id) => state.entries.findIndex(
 const state = {
   lists: [],
   entries: [],
+  statuses: [
+    { enum: 1, name: 'Reading' },
+    { enum: 2, name: 'On Hold' },
+    { enum: 3, name: 'Plan to Read' },
+    { enum: 4, name: 'Completed' },
+    { enum: 5, name: 'Dropped' },
+  ],
   listsLoading: false,
 };
 
 const getters = {
   // TODO: Rename to getEntriesByTagIDs when renaming manga lists to tags
   getEntriesByListIDs: (state) => (listIDs) => state.entries.filter(
-    (entry) => !listIDs.length || listIDs.includes(entry.manga_list_id.toString())
+    (entry) => entry.manga_list_id
+      && listIDs.includes(entry.manga_list_id.toString())
   ),
-  findListByID: (state) => (id) => state.lists.find((list) => list.id === id),
+  getEntriesByStatus: (state) => (status) => state.entries.filter(
+    (entry) => status === -1 || entry.attributes.status === status
+  ),
   findEntryFromIDs: (state) => (ids) => state.entries.find(
     (entry) => ids.includes(entry.id)
   ),

--- a/tests/components/TheMangaList.spec.js
+++ b/tests/components/TheMangaList.spec.js
@@ -30,7 +30,8 @@ describe('TheMangaList.vue', () => {
                 { id: '2', attributes: { name: 'Completed' } }
               ),
             ],
-            entries: [factories.entry.build({ id: '1' })],
+            entries: defaultEntries,
+            statuses: lists.state.statuses,
           },
           mutations: lists.mutations,
           getters: lists.getters,
@@ -47,11 +48,11 @@ describe('TheMangaList.vue', () => {
   });
 
   describe('when showing entries', () => {
-    it('displays manga list name for each entry', async () => {
+    it('displays status name for each entry', async () => {
       const entry1 = factories.entry.build({ id: '1' });
-      const entry2 = factories.entry.build({ id: '2', manga_list_id: 2 });
+      const entry2 = factories.entry.build({ id: '2', attributes: { status: 4 } });
 
-      mangaList.setData({ sortedData: [entry1, entry2] });
+      mangaList.setProps({ tableData: [entry1, entry2] });
 
       await nextTick();
 

--- a/tests/components/manga_entries/AddMangaEntry.spec.js
+++ b/tests/components/manga_entries/AddMangaEntry.spec.js
@@ -13,17 +13,12 @@ describe('AddMangaEntry.vue', () => {
   let store;
   let addMangaEntry;
 
-  const mangaList = factories.list.build();
-
   beforeEach(() => {
     store = new Vuex.Store({
       modules: {
         lists: {
           namespaced: true,
-          state: {
-            lists: [mangaList],
-            entries: [],
-          },
+          state: lists.state,
           mutations: lists.mutations,
           getters: lists.getters,
         },
@@ -31,18 +26,6 @@ describe('AddMangaEntry.vue', () => {
     });
 
     addMangaEntry = shallowMount(AddMangaEntry, { store, localVue });
-  });
-
-  describe(':lifecycle', () => {
-    it(':mounted() - sets manga list to Reading', () => {
-      addMangaEntry = shallowMount(AddMangaEntry, {
-        store,
-        localVue,
-        data() { return { listID: '' }; },
-      });
-
-      expect(addMangaEntry.vm.listID).toEqual(mangaList.id);
-    });
   });
 
   describe('when adding new MangaDex entry', () => {
@@ -55,13 +38,11 @@ describe('AddMangaEntry.vue', () => {
     });
 
     afterEach(() => {
-      expect(addMangaEntrySpy).toHaveBeenCalledWith(
-        'example.url/manga/1', mangaList.id
-      );
+      expect(addMangaEntrySpy).toHaveBeenCalledWith('example.url/manga/1', 1);
     });
 
     describe('when no manga sources are tracked', () => {
-      it('adds new Manga entry to the list', async () => {
+      it('adds new Manga entry', async () => {
         const mangaEntry = factories.entry.build();
 
         addMangaEntrySpy.mockResolvedValue({ data: mangaEntry });
@@ -84,7 +65,6 @@ describe('AddMangaEntry.vue', () => {
           id: 2,
           manga_source_id: 2,
           manga_series_id: oldEntry.manga_series_id,
-          manga_list_id: oldEntry.manga_list_id,
           attributes: {
             tracked_entries: [
               {

--- a/tests/components/manga_entries/EditMangaEntries.spec.js
+++ b/tests/components/manga_entries/EditMangaEntries.spec.js
@@ -46,13 +46,13 @@ describe('EditMangaEntries.vue', () => {
       });
 
 
-      it('prefills manga list', async () => {
+      it('prefills status', async () => {
         editMangaEntries.setProps({ selectedEntries: [entry1] });
 
         await nextTick();
 
-        expect(editMangaEntries.vm.$data.listID).toEqual(
-          entry1.manga_list_id.toString()
+        expect(editMangaEntries.vm.$data.selectedStatus).toEqual(
+          entry1.attributes.status
         );
       });
 
@@ -84,7 +84,7 @@ describe('EditMangaEntries.vue', () => {
           await flushPromises();
 
           expect(editMangaEntries.vm.$data).toEqual({
-            listID: entry1.manga_list_id.toString(),
+            selectedStatus: entry1.attributes.status,
             mangaSourceID: null,
             availableSources: [],
             loadingSources: true,
@@ -113,13 +113,15 @@ describe('EditMangaEntries.vue', () => {
 
     afterEach(() => {
       expect(updateMangaEntryMock).toHaveBeenCalledWith(
-        1, { manga_list_id: '2', manga_source_id: 1 }
+        1, { status: 2, manga_source_id: 1 }
       );
     });
 
     it('uses updateMangaEntry endpoint', async () => {
-      editMangaEntries.setData({ listID: '2', mangaSourceID: 1 });
-      const updatedEntry = factories.entry.build({ id: 1, manga_list_id: 2 });
+      editMangaEntries.setData({ selectedStatus: 2, mangaSourceID: 1 });
+      const updatedEntry = factories.entry.build({
+        id: 1, attributes: { status: 2 },
+      });
 
       updateMangaEntryMock.mockResolvedValue(updatedEntry);
 
@@ -146,20 +148,20 @@ describe('EditMangaEntries.vue', () => {
       });
 
       updatedMangaEntries = [
-        factories.entry.build({ id: 1, manga_list_id: 2 }),
-        factories.entry.build({ id: 2, manga_list_id: 2 }),
+        factories.entry.build({ id: 1, attributes: { status: 2 } }),
+        factories.entry.build({ id: 2, attributes: { status: 2 } }),
       ];
     });
 
     afterEach(() => {
       expect(updateMangaEntriesMock).toHaveBeenCalledWith(
-        [1, 2], { manga_list_id: '2' }
+        [1, 2], { status: 2 }
       );
     });
 
     describe('if update was successful', () => {
       beforeEach(() => {
-        editMangaEntries.setData({ listID: '2' });
+        editMangaEntries.setData({ selectedStatus: 2 });
 
         updateMangaEntriesMock.mockResolvedValue(updatedMangaEntries);
       });
@@ -182,7 +184,7 @@ describe('EditMangaEntries.vue', () => {
         expect(infoMessageMock).toHaveBeenCalledWith('2 entries updated');
       });
 
-      it('changes manga entries manga list', async () => {
+      it('changes manga entries status', async () => {
         editMangaEntries.vm.updateMangaEntries();
 
         await flushPromises();
@@ -195,7 +197,7 @@ describe('EditMangaEntries.vue', () => {
       it("shows couldn't update message and keeps same entries", async () => {
         const errorMessageMock = jest.spyOn(Message, 'error');
 
-        editMangaEntries.setData({ listID: '2' });
+        editMangaEntries.setData({ selectedStatus: 10 });
         updateMangaEntriesMock.mockResolvedValue(false);
 
         editMangaEntries.vm.updateMangaEntries();

--- a/tests/services/api.spec.js
+++ b/tests/services/api.spec.js
@@ -9,12 +9,12 @@ describe('API', () => {
   describe('addMangaEntry()', () => {
     it('makes a request to the API and returns manga if found', async () => {
       const mangaURL = 'example.url/123';
-      const mangaListID = 1;
+      const status = 1;
       const mockData = factories.entry.build();
 
       axios.post.mockResolvedValue({ status: 200, data: mockData });
 
-      const data = await apiService.addMangaEntry(mangaURL, mangaListID);
+      const data = await apiService.addMangaEntry(mangaURL, status);
       expect(data).toEqual(mockData);
     });
 

--- a/tests/store/modules/lists.spec.js
+++ b/tests/store/modules/lists.spec.js
@@ -12,6 +12,7 @@ describe('lists', () => {
         const state = {
           entries: [
             expectedReturn,
+            factories.entry.build({ manga_list_id: null }),
             factories.entry.build({ manga_list_id: 2 }),
           ],
         };
@@ -19,6 +20,34 @@ describe('lists', () => {
         const getEntriesByListIDs = lists.getters.getEntriesByListIDs(state);
 
         expect(getEntriesByListIDs(listIDs)).toEqual([expectedReturn]);
+      });
+    });
+
+    describe('getEntriesByStatus', () => {
+      it('returns entries based on status enum', () => {
+        const expectedReturn = factories.entry.build({
+          attributes: { status: 4 },
+        });
+        const state = {
+          entries: [
+            expectedReturn,
+            factories.entry.build({ attributes: { status: 1 } }),
+          ],
+        };
+
+        const getEntriesByStatus = lists.getters.getEntriesByStatus(state);
+
+        expect(getEntriesByStatus(4)).toEqual([expectedReturn]);
+      });
+
+      it('returns all entries if enum is -1', () => {
+        const entry1 = factories.entry.build({ attributes: { status: 1 } });
+        const entry2 = factories.entry.build({ attributes: { status: 2 } });
+        const state  = { entries: [entry1, entry2] };
+
+        const getEntriesByStatus = lists.getters.getEntriesByStatus(state);
+
+        expect(getEntriesByStatus(-1)).toEqual([entry1, entry2]);
       });
     });
 
@@ -32,17 +61,6 @@ describe('lists', () => {
         const findEntryFromIDs = lists.getters.findEntryFromIDs(state);
 
         expect(findEntryFromIDs([entry.id])).toEqual(entry);
-      });
-    });
-
-    describe('findListByID', () => {
-      it('returns list based on list ID provided', () => {
-        const list  = factories.list.build({ id: 2 });
-        const state = { lists: [list] };
-
-        const findListByID = lists.getters.findListByID(state);
-
-        expect(findListByID(2)).toEqual(list);
       });
     });
   });


### PR DESCRIPTION
This PR brings the remaining work on the filters work.

1.  Add new status filter, that is a single select, for choosing from our hardcoded status fields as well as all of them
2.  Removes manga list (soon to be replaced with tags) assignment and column, until lists are fully migrated into tags system
3.  If the user has custom lists defined (those matching reading statuses, will be removed), those will be shown in the tag filter, that has been added previously. Soon, users will be able to create their own tags, but those who don't want to use that system, will not see the filter, if no tags are available

![](https://user-images.githubusercontent.com/4270980/81482682-cb975700-9230-11ea-9701-9ec44c9e7980.gif)