### PR TITLE
Add jest dom

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-  setupFiles: ['<rootDir>/tests/setup'],
+  setupFilesAfterEnv: ['<rootDir>/tests/setup'],
   moduleFileExtensions: [
     'js',
     'jsx',

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "vuex-persist": "^2.2.0"
   },
   "devDependencies": {
+    "@testing-library/jest-dom": "^5.7.0",
     "@vue/cli-plugin-babel": "~4.2.3",
     "@vue/cli-plugin-eslint": "~4.2.3",
     "@vue/cli-plugin-unit-jest": "~4.2.3",

--- a/tests/components/base_components/BaseModal.spec.js
+++ b/tests/components/base_components/BaseModal.spec.js
@@ -53,25 +53,25 @@ describe('BaseModal.vue', () => {
       it('xs - sets body to be extra small', async () => {
         await baseModal.setProps({ size: 'xs' });
 
-        expect(body.classes()).toContain('sm_max-w-xs');
+        expect(body.element).toHaveClass('sm_max-w-xs');
       });
 
       it('sm - sets body to be small', async () => {
         await baseModal.setProps({ size: 'sm' });
 
-        expect(body.classes()).toContain('sm_max-w-sm');
+        expect(body.element).toHaveClass('sm_max-w-sm');
       });
 
       it('md - sets body to be medium', async () => {
         await baseModal.setProps({ size: 'md' });
 
-        expect(body.classes()).toContain('sm_max-w-md');
+        expect(body.element).toHaveClass('sm_max-w-md');
       });
 
       it('lg - sets body to be large', async () => {
         await baseModal.setProps({ size: 'lg' });
 
-        expect(body.classes()).toContain('sm_max-w-lg');
+        expect(body.element).toHaveClass('sm_max-w-lg');
       });
     });
   });

--- a/tests/components/base_components/BaseNavDark.spec.js
+++ b/tests/components/base_components/BaseNavDark.spec.js
@@ -125,13 +125,13 @@ describe('BaseNavDark.vue', () => {
           const profileDropdown = nav.find('.profile-dropdown');
           const menuDropdown    = nav.find('.menu-dropdown');
 
-          expect(profileDropdown.isVisible()).toBeTruthy();
-          expect(menuDropdown.isVisible()).toBeTruthy();
+          expect(profileDropdown.element).toBeVisible();
+          expect(menuDropdown.element).toBeVisible();
 
           await nav.find('.desktop-links').trigger('click');
 
-          expect(profileDropdown.isVisible()).toBeFalsy();
-          expect(menuDropdown.isVisible()).toBeFalsy();
+          expect(profileDropdown.element).not.toBeVisible();
+          expect(menuDropdown.element).not.toBeVisible();
         });
       });
     });

--- a/tests/components/base_components/BaseNavLight.spec.js
+++ b/tests/components/base_components/BaseNavLight.spec.js
@@ -125,13 +125,13 @@ describe('BaseNavLight.vue', () => {
           const profileDropdown = nav.find('.profile-dropdown');
           const menuDropdown    = nav.find('.menu-dropdown');
 
-          expect(profileDropdown.isVisible()).toBeTruthy();
-          expect(menuDropdown.isVisible()).toBeTruthy();
+          expect(profileDropdown.element).toBeVisible();
+          expect(menuDropdown.element).toBeVisible();
 
           await nav.find('.desktop-links').trigger('click');
 
-          expect(profileDropdown.isVisible()).toBeFalsy();
-          expect(menuDropdown.isVisible()).toBeFalsy();
+          expect(profileDropdown.element).not.toBeVisible();
+          expect(menuDropdown.element).not.toBeVisible();
         });
       });
     });

--- a/tests/components/manga_entries/ReportMangaEntries.spec.js
+++ b/tests/components/manga_entries/ReportMangaEntries.spec.js
@@ -33,13 +33,13 @@ describe('ReportMangaEntries.vue', () => {
 
     await reportMangaEntries.setData({ currentIssue: 1 });
 
-    expect(button.attributes('disabled')).toBeTruthy();
+    expect(button.element).toHaveAttribute('disabled');
 
     await reportMangaEntries.setProps({
       selectedEntries: factories.entry.buildList(2),
     });
 
-    expect(button.attributes('disabled')).toBeFalsy();
+    expect(button.element).not.toHaveAttribute('disabled');
   });
 
   describe('when reporting issues', () => {

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -1,6 +1,7 @@
 import Vue from 'vue';
 import fs from 'fs';
 import path from 'path';
+import '@testing-library/jest-dom';
 import { factories } from './factories';
 
 // ===

--- a/tests/views/Home.spec.js
+++ b/tests/views/Home.spec.js
@@ -37,7 +37,7 @@ describe('Home.vue', () => {
         stubs: ['router-link', 'router-view'],
       });
 
-      expect(home.find('base-banner-stub').isVisible()).toBeTruthy();
+      expect(home.find('base-banner-stub').element).toBeVisible();
     });
   });
 

--- a/tests/views/Home.spec.js
+++ b/tests/views/Home.spec.js
@@ -53,9 +53,7 @@ describe('Home.vue', () => {
 
       home.setData({ updateBanner: { id: 1 } });
 
-      expect(home.find({ ref: 'banner' }).attributes('style')).toContain(
-        'height: 0px;'
-      );
+      expect(home.find({ ref: 'banner' }).element).toHaveStyle('height: 0px');
     });
   });
 });

--- a/tests/views/MangaList.spec.js
+++ b/tests/views/MangaList.spec.js
@@ -88,7 +88,7 @@ describe('MangaList.vue', () => {
     it('shows add manga entry modal', async () => {
       await mangaList.find({ ref: 'addMangaEntryModalButton' }).trigger('click');
 
-      expect(modal.isVisible()).toBeTruthy();
+      expect(modal.element).toBeVisible();
     });
 
     describe('@events', () => {
@@ -125,7 +125,7 @@ describe('MangaList.vue', () => {
     it('shows edit manga entries modal', async () => {
       await mangaList.find({ ref: 'editMangaEntriesButton' }).trigger('click');
 
-      expect(modal.isVisible()).toBeTruthy();
+      expect(modal.element).toBeVisible();
     });
 
     describe('@events', () => {
@@ -259,15 +259,15 @@ describe('MangaList.vue', () => {
       const editButton = mangaList.find({ ref: 'editMangaEntriesButton' });
       const reportButton = mangaList.find({ ref: 'reportMangaEntriesButton' });
 
-      expect(deleteButton.isVisible()).not.toBeTruthy();
-      expect(editButton.isVisible()).not.toBeTruthy();
-      expect(reportButton.isVisible()).not.toBeTruthy();
+      expect(deleteButton.element).not.toBeVisible();
+      expect(editButton.element).not.toBeVisible();
+      expect(reportButton.element).not.toBeVisible();
 
       await mangaList.find(TheMangaList).vm.$emit('seriesSelected', [entry1]);
 
-      expect(deleteButton.isVisible()).toBeTruthy();
-      expect(editButton.isVisible()).toBeTruthy();
-      expect(reportButton.isVisible()).toBeTruthy();
+      expect(deleteButton.element).toBeVisible();
+      expect(editButton.element).toBeVisible();
+      expect(reportButton.element).toBeVisible();
       expect(mangaList.vm.$data.selectedEntries).toContain(entry1);
     });
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -895,6 +895,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.9.2":
+  version "7.9.6"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.9.6.tgz#a9102eb5cadedf3f31d08a9ecf294af7827ea29f"
+  integrity sha512-64AF1xY3OAkFHqOb9s4jpgk1Mm5vDZ4L3acHvAml+53nO1XbXLuDodsVpO4OIUsmemlUHMxNdYMNJmsvOwLrvQ==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/template@^7.1.0":
   version "7.4.4"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.4.4.tgz#f4b88d1225689a08f5bc3a17483545be9e4ed237"
@@ -1208,6 +1215,16 @@
     "@types/istanbul-reports" "^1.1.1"
     "@types/yargs" "^13.0.0"
 
+"@jest/types@^25.5.0":
+  version "25.5.0"
+  resolved "https://registry.yarnpkg.com/@jest/types/-/types-25.5.0.tgz#4d6a4793f7b9599fc3680877b856a97dbccf2a9d"
+  integrity sha512-OXD0RgQ86Tu3MazKo8bnrkDRaDXXMGUqd+kTtLtK1Zb7CRzQcaSRPPPV37SvYTdevXEBVxe0HXylEjs8ibkmCw==
+  dependencies:
+    "@types/istanbul-lib-coverage" "^2.0.0"
+    "@types/istanbul-reports" "^1.1.1"
+    "@types/yargs" "^15.0.0"
+    chalk "^3.0.0"
+
 "@mrmlnc/readdir-enhanced@^2.2.1":
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz#524af240d1a360527b730475ecfa1344aa540dde"
@@ -1247,6 +1264,21 @@
     "@tailwindcss/custom-forms" "^0.2.1"
     hex-to-rgba "^2.0.1"
     postcss-selector-parser "^6.0.2"
+
+"@testing-library/jest-dom@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@testing-library/jest-dom/-/jest-dom-5.7.0.tgz#b2e2acb4c088a293d52ba2cd1674b526282a2f87"
+  integrity sha512-ZV0OtBXmTDEDxrIbqJXiOcXCZ6aIMpmDlmfHj0hGNsSuQ/nX0qPAs9HWmCzXvPfTrhufTiH2nJLvDJu/LgHzwQ==
+  dependencies:
+    "@babel/runtime" "^7.9.2"
+    "@types/testing-library__jest-dom" "^5.0.2"
+    chalk "^3.0.0"
+    css "^2.2.4"
+    css.escape "^1.5.1"
+    jest-diff "^25.1.0"
+    jest-matcher-utils "^25.1.0"
+    lodash "^4.17.15"
+    redent "^3.0.0"
 
 "@types/babel-types@*", "@types/babel-types@^7.0.0":
   version "7.0.7"
@@ -1332,6 +1364,14 @@
     "@types/istanbul-lib-coverage" "*"
     "@types/istanbul-lib-report" "*"
 
+"@types/jest@*":
+  version "25.2.2"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-25.2.2.tgz#6a752e7a00f69c3e790ea00c345029d5cefa92bf"
+  integrity sha512-aRctFbG8Pb7DSLzUt/fEtL3q/GKb9mretFuYhRub2J0q6NhzBYbx9HTQzHrWgBNIxYOlxGNVe6Z54cpbUt+Few==
+  dependencies:
+    jest-diff "^25.2.1"
+    pretty-format "^25.2.1"
+
 "@types/jest@^24.0.19":
   version "24.0.24"
   resolved "https://registry.yarnpkg.com/@types/jest/-/jest-24.0.24.tgz#0f2f523dc77cc1bc6bef34eaf287ede887a73f05"
@@ -1374,6 +1414,13 @@
   resolved "https://registry.yarnpkg.com/@types/strip-json-comments/-/strip-json-comments-0.0.30.tgz#9aa30c04db212a9a0649d6ae6fd50accc40748a1"
   integrity sha512-7NQmHra/JILCd1QqpSzl8+mJRc8ZHz3uDm8YV1Ks9IhK0epEiTw8aIErbvH9PI+6XbqhyIQy3462nEsn7UVzjQ==
 
+"@types/testing-library__jest-dom@^5.0.2":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@types/testing-library__jest-dom/-/testing-library__jest-dom-5.6.0.tgz#325e97aacb7e4a66693e7face8a2c04f936f4a4b"
+  integrity sha512-VRl4kIzvtySjscCpMul3mz0UgEd40nG/jWluaXIYi5UG8cOOLD56u8IIgHZk+gSKmccRCsVv7AAg1HBmE7OQ2w==
+  dependencies:
+    "@types/jest" "*"
+
 "@types/yargs-parser@*":
   version "13.1.0"
   resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-13.1.0.tgz#c563aa192f39350a1d18da36c5a8da382bbd8228"
@@ -1383,6 +1430,13 @@
   version "13.0.3"
   resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-13.0.3.tgz#76482af3981d4412d65371a318f992d33464a380"
   integrity sha512-K8/LfZq2duW33XW/tFwEAfnZlqIfVsoyRB3kfXdPXYhl0nfM8mmh7GS0jg7WrX2Dgq/0Ha/pR1PaR+BvmWwjiQ==
+  dependencies:
+    "@types/yargs-parser" "*"
+
+"@types/yargs@^15.0.0":
+  version "15.0.5"
+  resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-15.0.5.tgz#947e9a6561483bdee9adffc983e91a6902af8b79"
+  integrity sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==
   dependencies:
     "@types/yargs-parser" "*"
 
@@ -3771,7 +3825,12 @@ css-what@2.1, css-what@^2.1.2:
   resolved "https://registry.yarnpkg.com/css-what/-/css-what-2.1.3.tgz#a6d7604573365fe74686c3f311c56513d88285f2"
   integrity sha512-a+EPoD+uZiNfh+5fxw2nO9QwFa6nJe2Or35fGY6Ipw1R3R4AGz1d1TEZrCegvw2YTmZ0jXirGYlzxxpYSHwpEg==
 
-css@^2.1.0:
+css.escape@^1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/css.escape/-/css.escape-1.5.1.tgz#42e27d4fa04ae32f931a4b4d4191fa9cddee97cb"
+  integrity sha1-QuJ9T6BK4y+TGktNQZH6nN3ul8s=
+
+css@^2.1.0, css@^2.2.4:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/css/-/css-2.2.4.tgz#c646755c73971f2bba6a601e2cf2fd71b1298929"
   integrity sha512-oUnjmWpy0niI3x/mPL8dVEI1l7MnG3+HHyRPHf+YFSbK+svOhXpmSOcDURUh2aOCgl2grzrOPt1nHLuCVFULLw==
@@ -4133,6 +4192,11 @@ diff-sequences@^24.9.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-24.9.0.tgz#5715d6244e2aa65f48bba0bc972db0b0b11e95b5"
   integrity sha512-Dj6Wk3tWyTE+Fo1rW8v0Xhwk80um6yFYKbuAxc9c3EZxIHFDYwbi34Uk42u1CdnIiVorvt4RmlSDjIPyzGC2ew==
+
+diff-sequences@^25.2.6:
+  version "25.2.6"
+  resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-25.2.6.tgz#5f467c00edd35352b7bca46d7927d60e687a76dd"
+  integrity sha512-Hq8o7+6GaZeoFjtpgvRBUknSXNeJiCx7V9Fr94ZMljNiCr9n9L8H8aJqgWOQiDDGdyn29fRNcDdRVJ5fdyihfg==
 
 diffie-hellman@^5.0.0:
   version "5.0.3"
@@ -6579,6 +6643,16 @@ jest-diff@^24.3.0, jest-diff@^24.9.0:
     jest-get-type "^24.9.0"
     pretty-format "^24.9.0"
 
+jest-diff@^25.1.0, jest-diff@^25.2.1, jest-diff@^25.5.0:
+  version "25.5.0"
+  resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-25.5.0.tgz#1dd26ed64f96667c068cef026b677dfa01afcfa9"
+  integrity sha512-z1kygetuPiREYdNIumRpAHY6RXiGmp70YHptjdaxTWGmA085W3iCnXNx0DhflK3vwrKmrRWyY1wUpkPMVxMK7A==
+  dependencies:
+    chalk "^3.0.0"
+    diff-sequences "^25.2.6"
+    jest-get-type "^25.2.6"
+    pretty-format "^25.5.0"
+
 jest-docblock@^24.3.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-24.9.0.tgz#7970201802ba560e1c4092cc25cbedf5af5a8ce2"
@@ -6636,6 +6710,11 @@ jest-get-type@^24.9.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-24.9.0.tgz#1684a0c8a50f2e4901b6644ae861f579eed2ef0e"
   integrity sha512-lUseMzAley4LhIcpSP9Jf+fTrQ4a1yHQwLNeeVa2cEmbCGeoZAtYPOIv8JaxLD/sUpKxetKGP+gsHl8f8TSj8Q==
+
+jest-get-type@^25.2.6:
+  version "25.2.6"
+  resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-25.2.6.tgz#0b0a32fab8908b44d508be81681487dbabb8d877"
+  integrity sha512-DxjtyzOHjObRM+sM1knti6or+eOgcGU4xVSb2HNP1TqO4ahsT+rqZg+nyqHWJSvWgKC5cG3QjGFBqxLghiF/Ig==
 
 jest-haste-map@^24.9.0:
   version "24.9.0"
@@ -6695,6 +6774,16 @@ jest-matcher-utils@^24.9.0:
     jest-diff "^24.9.0"
     jest-get-type "^24.9.0"
     pretty-format "^24.9.0"
+
+jest-matcher-utils@^25.1.0:
+  version "25.5.0"
+  resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-25.5.0.tgz#fbc98a12d730e5d2453d7f1ed4a4d948e34b7867"
+  integrity sha512-VWI269+9JS5cpndnpCwm7dy7JtGQT30UHfrnM3mXl22gHGt/b7NkjBqXfbhZ8V4B7ANUsjK18PlSBmG0YH7gjw==
+  dependencies:
+    chalk "^3.0.0"
+    jest-diff "^25.5.0"
+    jest-get-type "^25.2.6"
+    pretty-format "^25.5.0"
 
 jest-message-util@^24.9.0:
   version "24.9.0"
@@ -7645,6 +7734,11 @@ mimic-fn@^2.0.0, mimic-fn@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
   integrity sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
+
+min-indent@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/min-indent/-/min-indent-1.0.0.tgz#cfc45c37e9ec0d8f0a0ec3dd4ef7f7c3abe39256"
+  integrity sha1-z8RcN+nsDY8KDsPdTvf3w6vjklY=
 
 mini-css-extract-plugin@^0.9.0:
   version "0.9.0"
@@ -9235,6 +9329,16 @@ pretty-format@^24.9.0:
     ansi-styles "^3.2.0"
     react-is "^16.8.4"
 
+pretty-format@^25.2.1, pretty-format@^25.5.0:
+  version "25.5.0"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-25.5.0.tgz#7873c1d774f682c34b8d48b6743a2bf2ac55791a"
+  integrity sha512-kbo/kq2LQ/A/is0PQwsEHM7Ca6//bGPPvU6UnsdDRSKTWxT/ru/xb88v4BJf6a69H+uTytOEsTusT9ksd/1iWQ==
+  dependencies:
+    "@jest/types" "^25.5.0"
+    ansi-regex "^5.0.0"
+    ansi-styles "^4.0.0"
+    react-is "^16.12.0"
+
 pretty-hrtime@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz#b7e3ea42435a4c9b2759d99e0f201eb195802ee1"
@@ -9583,6 +9687,11 @@ rc@^1.2.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
+react-is@^16.12.0:
+  version "16.13.1"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
+  integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
+
 react-is@^16.8.4:
   version "16.11.0"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.11.0.tgz#b85dfecd48ad1ce469ff558a882ca8e8313928fa"
@@ -9693,6 +9802,14 @@ realpath-native@^1.1.0:
   integrity sha512-wlgPA6cCIIg9gKz0fgAPjnzh4yR/LnXovwuo9hvyGvx3h8nX4+/iLZplfUWasXpqD8BdnGnP5njOFjkUwPzvjA==
   dependencies:
     util.promisify "^1.0.0"
+
+redent@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/redent/-/redent-3.0.0.tgz#e557b7998316bb53c9f1f56fa626352c6963059f"
+  integrity sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==
+  dependencies:
+    indent-string "^4.0.0"
+    strip-indent "^3.0.0"
 
 reduce-css-calc@^2.1.6:
   version "2.1.7"
@@ -10762,6 +10879,13 @@ strip-indent@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/strip-indent/-/strip-indent-2.0.0.tgz#5ef8db295d01e6ed6cbf7aab96998d7822527b68"
   integrity sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=
+
+strip-indent@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/strip-indent/-/strip-indent-3.0.0.tgz#c32e1cee940b6b3432c771bc2c54bcce73cd3001"
+  integrity sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==
+  dependencies:
+    min-indent "^1.0.0"
 
 strip-json-comments@^2.0.0, strip-json-comments@~2.0.1:
   version "2.0.1"


### PR DESCRIPTION
Vue test utils is removing `isVisible()` matcher and recommends using [jest-dom](https://github.com/testing-library/jest-dom) instead. This PR does exactly that, but also replaces other instances, where jest-dom matcher are nicer than what vue test utils provides