### PR TITLE
Fix not passing remember me token

### DIFF
--- a/src/components/TheSignIn.vue
+++ b/src/components/TheSignIn.vue
@@ -22,7 +22,7 @@
         @keyup.enter.native='submitForm'
       )
     el-form-item.mb-0
-      el-checkbox(v-model="remembered") Remember Me (2 months)
+      el-checkbox(v-model="user.remember_me") Remember Me (2 months)
       base-button(ref='signInSubmit' @click='submitForm') Sign In
     .text-center
       el-link.mt-4(
@@ -61,8 +61,8 @@
         user: {
           email: '',
           password: '',
+          remember_me: false,
         },
-        remembered: false,
         rules: {
           email: [
             {

--- a/tests/components/TheSignIn.spec.js
+++ b/tests/components/TheSignIn.spec.js
@@ -46,16 +46,43 @@ describe('TheSignIn.vue', () => {
   });
 
   describe(':props', () => {
-    it.skip('delegates to store to sign in user if form is valid', async () => {
-      signIn.setData({ email: 'text@example.com', password: 'password' });
+    describe('when form is valid', () => {
+      it('delegates to store to sign in user', async () => {
+        const userData = {
+          email: 'text@example.com',
+          password: 'password',
+          remember_me: true,
+        };
+        const actions = { signIn: jest.fn() };
+        const store = new Vuex.Store({
+          modules: {
+            user: {
+              namespaced: true,
+              state: user.state,
+              actions,
+              getters: user.getters,
+            },
+          },
+        });
 
-      signIn.find({ ref: 'signInSubmit' }).trigger('click');
+        signIn = mount(TheSignIn, {
+          store,
+          localVue,
+          data() { return { user: userData }; },
+        });
+
+        signIn.find({ ref: 'signInSubmit' }).trigger('click');
+
+        expect(actions.signIn).toHaveBeenCalledWith(expect.anything(), userData);
+      });
     });
 
-    it('shows validation errors if form is invalid', async () => {
-      await signIn.find({ ref: 'signInSubmit' }).trigger('click');
+    describe('when form is invalid', () => {
+      it('shows validation errors', async () => {
+        await signIn.find({ ref: 'signInSubmit' }).trigger('click');
 
-      expect(signIn.text()).toContain("Password can't be blank");
+        expect(signIn.text()).toContain("Password can't be blank");
+      });
     });
   });
 });


### PR DESCRIPTION
At some point, I stopped passing in `remember_me` token, when signing user in. This resulted in people getting signed out prematurely, even though they checked remember me field