### PR TITLE
Bulk actions use button group instead of circular buttons

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -33,6 +33,7 @@ module.exports = {
   coveragePathIgnorePatterns: [
     '/node_modules/',
     'src/modules/',
+    'src/components/icons',
     'tests/factories/',
     'tests/fixtures/',
   ],

--- a/src/components/BulkActions.vue
+++ b/src/components/BulkActions.vue
@@ -1,0 +1,99 @@
+<template lang="pug">
+  transition(
+    enter-active-class='slide-transition'
+    enter-class='opacity-0 transform translate-y-8'
+    leave-active-class='slide-transition'
+    leave-to-class='opacity-0 transform translate-y-8'
+  )
+    span.relative.z-0.inline-flex.shadow-sm
+      button.group(
+        v-for='(button, index) in buttons'
+        @click="$emit(button.action)"
+        :key="index"
+        :class="buttonClasses(index)"
+      )
+        component.-ml-1.mr-2.h-5.w-5.text-gray-400(
+          :is='button.icon'
+          :class="hoverClasses(button.action)"
+        )
+        span(
+          v-text="button.text"
+          :class="hoverClasses(button.action)"
+        )
+</template>
+
+<script>
+  import trashIcon from './icons/heroTrash';
+  import editIcon from './icons/heroEdit';
+  import warningIcon from './icons/heroWarning';
+
+  export default {
+    components: {
+      trashIcon,
+      editIcon,
+      warningIcon,
+    },
+    data() {
+      return {
+        buttons: [
+          {
+            text: 'Delete',
+            action: 'delete',
+            icon: 'trashIcon',
+          },
+          {
+            text: 'Edit',
+            action: 'edit',
+            icon: 'editIcon',
+          },
+          {
+            text: 'Report',
+            action: 'report',
+            icon: 'warningIcon',
+          },
+
+        ],
+      };
+    },
+    methods: {
+      buttonClasses(index) {
+        return {
+          'rounded-l-md': index === 0,
+          '-ml-px': index !== 0,
+          'rounded-r-md': index === this.buttons.length - 1,
+        };
+      },
+      hoverClasses(action) {
+        return {
+          'group-hover_text-red-400': action === 'delete',
+          'group-hover_text-gray-800': action === 'edit',
+          'group-hover_text-yellow-400': action === 'report',
+        };
+      },
+    },
+  };
+</script>
+
+<style lang="scss" scoped>
+  button {
+    @apply relative inline-flex items-center px-4 py-2 border border-gray-300;
+    @apply bg-white text-sm leading-5 font-medium text-gray-700;
+    @apply transition ease-in-out duration-150;
+
+    &:hover {
+      @apply text-gray-500;
+    }
+
+    &:focus {
+      @apply z-10 outline-none border-gray-300 shadow-none;
+    }
+
+    &:active {
+      @apply bg-gray-100 text-gray-700;
+    }
+  }
+
+  .slide-transition {
+    @apply transition ease-in duration-300 transition-all overflow-hidden;
+  }
+</style>

--- a/src/components/icons/heroEdit.vue
+++ b/src/components/icons/heroEdit.vue
@@ -1,0 +1,23 @@
+<template lang="html">
+  <svg
+    fill="none"
+    stroke="currentColor"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    stroke-width="2"
+    viewBox="0 0 24 24"
+  ><path :d="d" /></svg>
+</template>
+
+<script>
+  export default {
+    data() {
+      return {
+        d: `
+          M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2
+          2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z
+        `,
+      };
+    },
+  };
+</script>

--- a/src/components/icons/heroTrash.vue
+++ b/src/components/icons/heroTrash.vue
@@ -1,0 +1,25 @@
+<template lang="html">
+  <svg
+    fill="none"
+    stroke="currentColor"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    stroke-width="2"
+    viewBox="0 0 24 24"
+  >
+    <path :d="d" />
+  </svg>
+</template>
+
+<script>
+  export default {
+    data() {
+      return {
+        d: `
+          M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5
+          4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16
+        `,
+      };
+    },
+  };
+</script>

--- a/src/components/icons/heroWarning.vue
+++ b/src/components/icons/heroWarning.vue
@@ -1,0 +1,23 @@
+<template lang="html">
+  <svg
+    fill="none"
+    stroke="currentColor"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    stroke-width="2"
+    viewBox="0 0 24 24"
+  ><path :d="d" /></svg>
+</template>
+
+<script>
+  export default {
+    data() {
+      return {
+        d: `
+          M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732
+          4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z
+        `,
+      };
+    },
+  };
+</script>

--- a/src/views/MangaList.vue
+++ b/src/views/MangaList.vue
@@ -43,40 +43,12 @@
               placeholder='Input manga title'
             )
       .mx-5.mb-5.max-sm_mx-2.max-sm_flex.max-sm_flex-col
-        .bulk-actions.inline-block.max-sm_mb-5.max-sm_float-right
-          el-button.sm_shadow(
-            v-show="entriesSelected"
-            content="Delete"
-            ref="removeSeriesButton"
-            icon="el-icon-delete"
-            type="danger"
-            size="medium"
-            @click="deleteEntries"
-            circle
-            v-tippy
-          )
-          el-button.sm_shadow(
-            v-show="entriesSelected"
-            content="Edit"
-            ref="editMangaEntriesButton"
-            icon="el-icon-edit-outline"
-            type="info"
-            size="medium"
-            @click="editDialogVisible = true"
-            circle
-            v-tippy
-          )
-          el-button.sm_shadow(
-            v-show="entriesSelected"
-            content="Report manga issues"
-            ref="reportMangaEntriesButton"
-            icon="el-icon-document-delete"
-            type="warning"
-            size="medium"
-            @click="reportDialogVisible = true"
-            circle
-            v-tippy
-          )
+        bulk-actions.mb-3.sm_mb-0(
+          v-show="entriesSelected"
+          @delete="deleteEntries"
+          @edit="editDialogVisible = true"
+          @report="reportDialogVisible = true"
+        )
         .actions.inline-block.float-right.sm_flex.sm_flex-row-reverse
           span.sm_ml-3.flex.w-full.rounded-md.shadow-sm.sm_w-auto
             base-button(
@@ -131,10 +103,11 @@
     mapActions, mapState, mapMutations, mapGetters,
   } from 'vuex';
   import {
-    Message, Button, Input, Select, Option,
+    Message, Input, Select, Option,
   } from 'element-ui';
 
   import Importers from '@/components/TheImporters';
+  import BulkActions from '@/components/BulkActions';
   import AddMangaEntry from '@/components/manga_entries/AddMangaEntry';
   import DeleteMangaEntries from '@/components/manga_entries/DeleteMangaEntries';
   import EditMangaEntries from '@/components/manga_entries/EditMangaEntries';
@@ -146,12 +119,12 @@
     name: 'MangaList',
     components: {
       Importers,
+      BulkActions,
       AddMangaEntry,
       EditMangaEntries,
       DeleteMangaEntries,
       ReportMangaEntries,
       TheMangaList,
-      'el-button': Button,
       'el-input': Input,
       'el-select': Select,
       'el-option': Option,
@@ -288,9 +261,3 @@
     },
   };
 </script>
-
-<style media="screen" lang="scss">
-  .el-button.float-right + .el-button.float-right {
-    @apply ml-0;
-  }
-</style>

--- a/tests/components/BulkActions.spec.js
+++ b/tests/components/BulkActions.spec.js
@@ -1,0 +1,24 @@
+import BulkActions from '@/components/BulkActions.vue';
+
+describe('BulkActions.vue', () => {
+  it('renders renders bulk actions button group', () => {
+    const bulkActions = shallowMount(BulkActions);
+
+    expect(bulkActions.html()).toMatchSnapshot();
+  });
+
+  describe('when pressing a button', () => {
+    it('emits associated action', async () => {
+      const bulkActions = shallowMount(BulkActions);
+
+      await bulkActions.findAll('button').at(0).trigger('click');
+      expect(bulkActions.emitted('delete')).toBeTruthy();
+
+      await bulkActions.findAll('button').at(1).trigger('click');
+      expect(bulkActions.emitted('edit')).toBeTruthy();
+
+      await bulkActions.findAll('button').at(2).trigger('click');
+      expect(bulkActions.emitted('report')).toBeTruthy();
+    });
+  });
+});

--- a/tests/components/__snapshots__/BulkActions.spec.js.snap
+++ b/tests/components/__snapshots__/BulkActions.spec.js.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`BulkActions.vue renders renders bulk actions button group 1`] = `
+<transition-stub enterclass="opacity-0 transform translate-y-8" leavetoclass="opacity-0 transform translate-y-8" enteractiveclass="slide-transition" leaveactiveclass="slide-transition"><span class="relative z-0 inline-flex shadow-sm"><button class="group rounded-l-md"><trashicon-stub class="-ml-1 mr-2 h-5 w-5 text-gray-400 group-hover_text-red-400"></trashicon-stub><span class="group-hover_text-red-400">Delete</span></button><button class="group -ml-px">
+    <editicon-stub class="-ml-1 mr-2 h-5 w-5 text-gray-400 group-hover_text-gray-800"></editicon-stub><span class="group-hover_text-gray-800">Edit</span>
+  </button><button class="group -ml-px rounded-r-md">
+    <warningicon-stub class="-ml-1 mr-2 h-5 w-5 text-gray-400 group-hover_text-yellow-400"></warningicon-stub><span class="group-hover_text-yellow-400">Report</span>
+  </button></span></transition-stub>
+`;

--- a/tests/views/MangaList.spec.js
+++ b/tests/views/MangaList.spec.js
@@ -3,7 +3,7 @@ import { Message } from 'element-ui';
 import flushPromises from 'flush-promises';
 import MangaList from '@/views/MangaList.vue';
 import TheMangaList from '@/components/TheMangaList.vue';
-import TheImporters from '@/components/TheImporters.vue';
+import BulkActions from '@/components/BulkActions.vue';
 import AddMangaEntry from '@/components/manga_entries/AddMangaEntry.vue';
 import EditMangaEntries from '@/components/manga_entries/EditMangaEntries.vue';
 import lists from '@/store/modules/lists';
@@ -123,7 +123,7 @@ describe('MangaList.vue', () => {
     });
 
     it('shows edit manga entries modal', async () => {
-      await mangaList.find({ ref: 'editMangaEntriesButton' }).trigger('click');
+      await mangaList.find(BulkActions).vm.$emit('edit');
 
       expect(modal.element).toBeVisible();
     });
@@ -248,26 +248,15 @@ describe('MangaList.vue', () => {
     let mangaList;
 
     beforeEach(() => {
-      mangaList = shallowMount(MangaList, {
-        store,
-        localVue,
-      });
+      mangaList = shallowMount(MangaList, { store, localVue });
     });
 
     it('@seriesSelected - toggles bulk actions and sets selected series', async () => {
-      const deleteButton = mangaList.find({ ref: 'removeSeriesButton' });
-      const editButton = mangaList.find({ ref: 'editMangaEntriesButton' });
-      const reportButton = mangaList.find({ ref: 'reportMangaEntriesButton' });
-
-      expect(deleteButton.element).not.toBeVisible();
-      expect(editButton.element).not.toBeVisible();
-      expect(reportButton.element).not.toBeVisible();
+      expect(mangaList.find('bulk-actions-stub').element).not.toBeVisible();
 
       await mangaList.find(TheMangaList).vm.$emit('seriesSelected', [entry1]);
 
-      expect(deleteButton.element).toBeVisible();
-      expect(editButton.element).toBeVisible();
-      expect(reportButton.element).toBeVisible();
+      expect(mangaList.find('bulk-actions-stub').element).toBeVisible();
       expect(mangaList.vm.$data.selectedEntries).toContain(entry1);
     });
   });


### PR DESCRIPTION
Replaces old bulk action buttons, with a new button group, using TailwindUI

<table><tbody><tr><th>Before</th><td>After</td></tr><tr><th><figure class="image"><img src="https://user-images.githubusercontent.com/4270980/82738044-ea1b4900-9d2c-11ea-9af5-10e7beaf2d44.gif"></figure></th><td><figure class="image"><img src="https://user-images.githubusercontent.com/4270980/82753783-424f5b00-9dc0-11ea-902f-19d0226c73cf.gif"></figure></td></tr></tbody></table>