### PR TITLE
New MangaList layout and colour style

### DIFF
--- a/src/components/BulkActions.vue
+++ b/src/components/BulkActions.vue
@@ -6,7 +6,7 @@
     leave-to-class='opacity-0 transform translate-y-8'
   )
     span.relative.z-0.inline-flex.shadow-sm
-      button.group(
+      button.w-full.flex.justify-center.group(
         v-for='(button, index) in buttons'
         @click="$emit(button.action)"
         :key="index"

--- a/src/components/TheMangaList.vue
+++ b/src/components/TheMangaList.vue
@@ -1,12 +1,21 @@
 <template lang="pug">
   #mangaTable
-    el-table.sm_shadow-lg.sm_rounded(
+    el-table(
       ref="mangaListTable"
       :data="currentPageEntries"
       v-loading='listsLoading'
       @selection-change="handleSelectionChange"
       @sort-change="applySorting"
     )
+      template(slot='empty')
+        span.mt-2.leading-normal
+          template(v-if='entries.length || listsLoading')
+            | No entries found.
+            | Try changing your filters
+          template(v-else)
+            | You haven't imported manga yet. Add a new manga series by pressing
+            | Add Manga and providing a URL. Or press Import, to import your
+            | manga from TrackrMoe or MangaDex
       el-table-column(type="selection" width="35")
       el-table-column(
         prop="newReleases"
@@ -163,6 +172,7 @@
     },
     computed: {
       ...mapState('lists', [
+        'entries',
         'statuses',
         'listsLoading',
       ]),
@@ -231,10 +241,10 @@
 <style media="screen" lang="scss">
   .el-pagination {
     width: fit-content;
-    @apply my-5 p-0;
+    @apply my-5 p-0 shadow overflow-hidden;
 
     @screen sm {
-      @apply shadow-lg;
+      @apply rounded-md;
     }
   }
   .btn-prev {
@@ -256,11 +266,35 @@
     background-color: #409EFF;
     @apply h-2 w-2 p-0 rounded-full;
   }
+
+  .el-checkbox__inner {
+    @apply delay-0;
+  }
+
+  .el-table {
+    box-shadow: 0 4px 8px rgba(0, 0, 0, .12);
+
+    @screen sm {
+      @apply rounded-md;
+    }
+  }
+
+  .el-table th {
+    @apply border-b border-gray-200 text-xs leading-4 font-medium text-gray-500;
+    @apply uppercase tracking-wider;
+  }
   .el-table th > .cell {
     @apply break-normal;
   }
 
   .el-table td > .cell {
     @apply break-normal;
+  }
+  .el-table--enable-row-hover .el-table__body tr:hover>td {
+    @apply bg-gray-50;
+  }
+
+  .el-table__empty-text {
+    @apply leading-loose my-5;
   }
 </style>

--- a/src/components/base_components/BaseNavDark.vue
+++ b/src/components/base_components/BaseNavDark.vue
@@ -1,5 +1,5 @@
 <template lang="pug">
-  nav.z-20.bg-gray-800(ref="navigation")
+  nav.relative.z-20.bg-gray-800(ref="navigation")
     .max-w-7xl.mx-auto.px-2.sm_px-6.lg_px-8
       .relative.flex.items-center.justify-between.h-16
         .absolute.inset-y-0.left-0.flex.items-center.sm_hidden

--- a/src/components/base_components/BaseNavLight.vue
+++ b/src/components/base_components/BaseNavLight.vue
@@ -1,5 +1,5 @@
 <template lang="pug">
-  nav.z-20.bg-white.shadow
+  nav.relative.z-20.bg-white.shadow
     .max-w-7xl.mx-auto.px-2.sm_px-6.lg_px-8
       .relative.flex.justify-between.h-16
         .absolute.inset-y-0.left-0.flex.items-center.sm_hidden

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -1,7 +1,7 @@
 <template lang="pug">
   #home.h-full
     landing-page(v-if="landing")
-    .min-h-full.flex.flex-col.bg-blue-300(v-else)
+    .min-h-full.flex.flex-col.bg-gray-50(v-else)
       vue-slide-toggle(ref="banner" :open="bannerVisible" :duration="500")
         base-banner(
           :text="updateBanner.message"
@@ -14,7 +14,7 @@
         main.min-h-45
           transition(name="slide-left" mode="out-in")
             router-view
-      base-footer(dark).flex-shrink-0
+      base-footer.flex-shrink-0
 </template>
 
 <script>

--- a/src/views/MangaList.vue
+++ b/src/views/MangaList.vue
@@ -1,8 +1,9 @@
 <template lang="pug">
   .flex.flex-col.items-center
-    .flex.flex-col.w-full.max-w-7xl.py-6
-      .mx-5.mb-5.max-sm_mx-2
-        el-select.ml-3.sm_shadow-md.rounded.float-right.w-40(
+    .hidden.bg-white.h-64.w-full.absolute.border-b.border-gray-200.sm_block
+    .flex.flex-col.w-full.max-w-7xl.py-8
+      .mx-2.mb-5.sm_mx-5
+        el-select.w-full.sm_w-40(
           v-model="selectedStatus"
           placeholder="Filter by status"
           :disabled="listsLoading"
@@ -13,7 +14,7 @@
             :label="status.name"
             :value="status.enum"
           )
-        el-select.sm_shadow-md.rounded.float-right.w-48(
+        el-select.w-full.mt-3.sm_mt-0.sm_ml-3.sm_w-48(
           ref="tagFilter"
           v-if="lists.length"
           v-model="selectedListIDs"
@@ -28,9 +29,8 @@
             :label="list.attributes.name"
             :value="list.id"
           )
-      .mx-5.mb-5.max-sm_mx-2
-        .mt-3.text-center.sm_mt-0.sm_text-left.w-64.float-right
-          .mt-1.relative.rounded-md.shadow-sm
+        .mt-3.text-center.w-full.float-right.sm_mt-0.sm_text-left.sm_w-64
+          .relative.rounded-md.shadow-sm
             .absolute.inset-y-0.left-0.pl-3.flex.items-center.pointer-events-none
               svg.h-5.w-5.text-gray-400(fill='currentColor' viewbox='0 0 20 20')
                 path(
@@ -49,7 +49,7 @@
           @edit="editDialogVisible = true"
           @report="reportDialogVisible = true"
         )
-        .actions.inline-block.float-right.sm_flex.sm_flex-row-reverse
+        .actions.inline-block.float-right.sm_flex.sm_flex-row-reverse.relative
           span.sm_ml-3.flex.w-full.rounded-md.shadow-sm.sm_w-auto
             base-button(
               ref="addMangaEntryModalButton"
@@ -262,3 +262,9 @@
     },
   };
 </script>
+
+<style media="screen" lang="scss">
+  .el-input__inner {
+    @apply rounded-md;
+  }
+</style>

--- a/src/views/Sources.vue
+++ b/src/views/Sources.vue
@@ -1,7 +1,7 @@
 <template lang="pug">
   .max-w-7xl.px-8.my-10.mx-auto
     .grid.gap-10.grid-cols-1.sm_grid-cols-3.md_grid-cols-4.lg_grid-cols-6
-      a.no-underline.max-w-sm.rounded-lg.overflow-hidden.shadow-md.bg-white.hover_shadow-xl.transition.duration-200(
+      a.no-underline.max-w-sm.rounded-lg.overflow-hidden.shadow.bg-white.hover_shadow-lg.transition.duration-200(
         v-for='source in sources'
         :href='source.url'
         target="_blank"

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -22,6 +22,9 @@ module.exports = {
       full: '100%',
     },
     extend: {
+      transitionDelay: {
+        0: '0ms',
+      },
       colors: {
         'el-green': '#67C23A',
         'el-green-light': '#85CE61',

--- a/tests/components/__snapshots__/BulkActions.spec.js.snap
+++ b/tests/components/__snapshots__/BulkActions.spec.js.snap
@@ -1,9 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`BulkActions.vue renders renders bulk actions button group 1`] = `
-<transition-stub enterclass="opacity-0 transform translate-y-8" leavetoclass="opacity-0 transform translate-y-8" enteractiveclass="slide-transition" leaveactiveclass="slide-transition"><span class="relative z-0 inline-flex shadow-sm"><button class="group rounded-l-md"><trashicon-stub class="-ml-1 mr-2 h-5 w-5 text-gray-400 group-hover_text-red-400"></trashicon-stub><span class="group-hover_text-red-400">Delete</span></button><button class="group -ml-px">
+<transition-stub enterclass="opacity-0 transform translate-y-8" leavetoclass="opacity-0 transform translate-y-8" enteractiveclass="slide-transition" leaveactiveclass="slide-transition"><span class="relative z-0 inline-flex shadow-sm"><button class="w-full flex justify-center group rounded-l-md"><trashicon-stub class="-ml-1 mr-2 h-5 w-5 text-gray-400 group-hover_text-red-400"></trashicon-stub><span class="group-hover_text-red-400">Delete</span></button><button class="w-full flex justify-center group -ml-px">
     <editicon-stub class="-ml-1 mr-2 h-5 w-5 text-gray-400 group-hover_text-gray-800"></editicon-stub><span class="group-hover_text-gray-800">Edit</span>
-  </button><button class="group -ml-px rounded-r-md">
+  </button><button class="w-full flex justify-center group -ml-px rounded-r-md">
     <warningicon-stub class="-ml-1 mr-2 h-5 w-5 text-gray-400 group-hover_text-yellow-400"></warningicon-stub><span class="group-hover_text-yellow-400">Report</span>
   </button></span></transition-stub>
 `;


### PR DESCRIPTION
To allow to expand our pages and introduce new components, I needed to make a more neutral colour pallet for the site. At the same time, I wanted to introduce better verticality to the manga list, for a more interesting stacked layout. 

This is the result, which I think is much nicer than what we had previously and will allow me to continue updating the site with new UI components. The downside is that it's a stronger light theme, so a dark theme is even more needed now for night :owl: 

## Manga List default

![](https://user-images.githubusercontent.com/4270980/83329172-e1bc9400-a27f-11ea-9721-7704f82057c7.png)

## No entries, with new copy

![](https://user-images.githubusercontent.com/4270980/83329173-e1bc9400-a27f-11ea-9899-8e7261f15c1c.png)

## With bulk actions shown

![](https://user-images.githubusercontent.com/4270980/83329174-e1bc9400-a27f-11ea-9ba1-64ddce137f2c.png)

## New users see a new copy, to help them add new manga

![](https://user-images.githubusercontent.com/4270980/83329175-e1bc9400-a27f-11ea-8992-eeca68180ca5.png)

## Mobile view

![](https://user-images.githubusercontent.com/4270980/83329176-e2552a80-a27f-11ea-8ffd-dd010ec7e0c1.png)