### PR TITLE
Update registrations routes

### DIFF
--- a/src/components/TheSignUp.vue
+++ b/src/components/TheSignUp.vue
@@ -58,7 +58,7 @@
     Form, FormItem, Input, Message, Divider, Link,
   } from 'element-ui';
 
-  import { plain } from '@/modules/axios';
+  import { create } from '@/services/endpoints/auth/registrations';
 
   export default {
     components: {
@@ -137,9 +137,7 @@
       async signUp() {
         this.$emit('loading', true);
 
-        const response = await plain
-          .post('/api/v1/registrations/', { user: this.user })
-          .catch((e) => e.response);
+        const response = await create(this.user);
 
         if (response.status === 200) {
           this.confirmationInitiated = true;

--- a/src/services/endpoints/auth/registrations.js
+++ b/src/services/endpoints/auth/registrations.js
@@ -1,0 +1,10 @@
+import { plain } from '@/modules/axios';
+
+const baseURL = '/auth/registrations';
+
+/* eslint-disable import/prefer-default-export */
+export const create = (user) => plain
+  .post(baseURL, { user })
+  .then((request) => request)
+  .catch((request) => request.response);
+/* eslint-enable import/prefer-default-export */

--- a/tests/components/TheSignUp.spec.js
+++ b/tests/components/TheSignUp.spec.js
@@ -6,6 +6,7 @@ import { Message } from 'element-ui';
 import TheSignUp from '@/components/TheSignUp.vue';
 
 import user from '@/store/modules/user';
+import * as resource from '@/services/endpoints/auth/registrations';
 
 const localVue = createLocalVue();
 
@@ -54,23 +55,17 @@ describe('TheSignUp.vue', () => {
         });
       });
 
-      it.skip('delegates to store to sign in user if form is valid', async () => {
-        signUp.find({ ref: 'signUpSubmit' }).trigger('click');
-      });
+      it('delegates to the endpoint service and shows confirmation message', async () => {
+        const createUserSpy = jest.spyOn(resource, 'create');
 
-      it('POSTs to registrations endpoint and show confirmation message', async () => {
-        const axiosSpy = jest.spyOn(axios, 'post');
-
-        axiosSpy.mockResolvedValue({ status: 200 });
+        createUserSpy.mockResolvedValue({ status: 200 });
 
         signUp.vm.signUp();
 
         await flushPromises();
 
-        expect(axiosSpy).toHaveBeenCalledWith(
-          '/api/v1/registrations/',
-          { user: signUp.vm.$data.user }
-        );
+        expect(createUserSpy).toHaveBeenCalledWith(signUp.vm.$data.user);
+        expect(signUp.text()).toContain('Signed up successfully');
       });
     });
 
@@ -82,7 +77,7 @@ describe('TheSignUp.vue', () => {
       });
 
       it('shows server-side errors if request failed', async () => {
-        const axiosSpy        = jest.spyOn(axios, 'post');
+        const createUserSpy   = jest.spyOn(resource, 'create');
         const errorMessageSpy = jest.spyOn(Message, 'error');
 
         const mockResponse = {
@@ -91,7 +86,7 @@ describe('TheSignUp.vue', () => {
           },
         };
 
-        axiosSpy.mockRejectedValue(mockResponse);
+        createUserSpy.mockResolvedValue({ status: 404, mockResponse });
 
         signUp.vm.signUp();
 

--- a/tests/services/endpoints/auth/registrations.spec.js
+++ b/tests/services/endpoints/auth/registrations.spec.js
@@ -1,0 +1,38 @@
+import axios from 'axios';
+import * as resource from '@/services/endpoints/auth/registrations';
+
+describe('registrations', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('create()', () => {
+    let createSpy;
+
+    beforeEach(() => {
+      createSpy = jest.spyOn(axios, 'post');
+    });
+
+    it('makes a request to the resource and returns response', async () => {
+      createSpy.mockResolvedValue({ status: 200 });
+
+      const user = {
+        email: 'text@example.com',
+        password: 'password',
+        password_confirmation: 'password',
+      };
+      const successful = await resource.create(user);
+
+      expect(successful.status).toBe(200);
+      expect(createSpy).toHaveBeenCalledWith('/auth/registrations', { user });
+    });
+
+    it('makes a request to the resource and returns failed response', async () => {
+      createSpy.mockRejectedValue({ response: { status: 500 } });
+
+      const successful = await resource.create('');
+
+      expect(successful.status).toBe(500);
+    });
+  });
+});


### PR DESCRIPTION
Back-end has moved the endpoint for the registrations, so I need to match this on the client-side. I also refactored a bit, in preparation for expanding the endpoint, with the new service, matching those of passwords and confirmations