### PR TITLE
Prefill Reading Status when adding manga

### DIFF
--- a/src/components/manga_entries/AddMangaEntry.vue
+++ b/src/components/manga_entries/AddMangaEntry.vue
@@ -60,6 +60,10 @@
         type: Boolean,
         default: false,
       },
+      currentStatus: {
+        type: Number,
+        default: 1,
+      },
     },
     data() {
       return {
@@ -75,6 +79,11 @@
       ...mapGetters('lists', [
         'findEntryFromIDs',
       ]),
+    },
+    watch: {
+      currentStatus(status) {
+        this.selectedStatus = status === -1 ? 1 : status;
+      },
     },
     methods: {
       ...mapMutations('lists', [

--- a/src/views/MangaList.vue
+++ b/src/views/MangaList.vue
@@ -75,6 +75,7 @@
       add-manga-entry(
         ref='addMangaEntryModal'
         :visible="dialogVisible"
+        :currentStatus="selectedStatus"
         @dialogClosed='dialogVisible = false'
       )
       edit-manga-entries(

--- a/tests/components/manga_entries/AddMangaEntry.spec.js
+++ b/tests/components/manga_entries/AddMangaEntry.spec.js
@@ -28,6 +28,26 @@ describe('AddMangaEntry.vue', () => {
     addMangaEntry = shallowMount(AddMangaEntry, { store, localVue });
   });
 
+  describe(':props', () => {
+    describe(':currentStatus', () => {
+      it('sets initial selectedStatus', async () => {
+        expect(addMangaEntry.vm.selectedStatus).toBe(1);
+
+        await addMangaEntry.setProps({ currentStatus: 2 });
+
+        expect(addMangaEntry.vm.selectedStatus).toBe(2);
+      });
+
+      it('sets selectedStatus as Reading if currentStatus is All', async () => {
+        expect(addMangaEntry.vm.selectedStatus).toBe(1);
+
+        await addMangaEntry.setProps({ currentStatus: -1 });
+
+        expect(addMangaEntry.vm.selectedStatus).toBe(1);
+      });
+    });
+  });
+
   describe('when adding new MangaDex entry', () => {
     let addMangaEntrySpy;
 


### PR DESCRIPTION
Instead of always defaulting to `Reading` status, I want to use the status of the currently selected status, unless it's `All` manga entries