### PR TITLE
Fix click outside

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "lodash": "^4.17.15",
     "pug-plain-loader": "^1.0.0",
     "qs": "^6.9.3",
-    "v-click-outside": "^3.0.1",
     "vue": "^2.6.11",
     "vue-analytics": "^5.22.1",
     "vue-meta": "^2.3.3",

--- a/src/components/base_components/BaseNavDark.vue
+++ b/src/components/base_components/BaseNavDark.vue
@@ -131,19 +131,10 @@
       ]),
     },
     mounted() {
-      if (this.signedIn) {
-        document.addEventListener('click', (event) => {
-          event.stopPropagation();
-
-          const profileEl = this.$refs.profile;
-
-          if (this.profileVisible && !profileEl.contains(event.target)) {
-            this.profileVisible = false;
-          }
-
-          if (this.menuVisible) { this.menuVisible = false; }
-        });
-      }
+      document.addEventListener('click', this.handleClickOutside);
+    },
+    destroyed() {
+      document.removeEventListener('click', this.handleClickOutside);
     },
     methods: {
       ...mapActions('user', [
@@ -152,6 +143,17 @@
       openSignOnWith(comp) {
         this.activeSignOnComponent = comp;
         this.signOnVisible = true;
+      },
+      handleClickOutside(event) {
+        event.stopPropagation();
+
+        const { profile } = this.$refs;
+
+        if (this.profileVisible && !profile.contains(event.target)) {
+          this.profileVisible = false;
+        }
+
+        if (this.menuVisible) { this.menuVisible = false; }
       },
     },
   };

--- a/src/components/base_components/BaseNavLight.vue
+++ b/src/components/base_components/BaseNavLight.vue
@@ -132,20 +132,10 @@
       ]),
     },
     mounted() {
-      if (this.signedIn) {
-        document.addEventListener('click', (event) => {
-          event.stopPropagation();
-
-          const { profile } = this.$refs;
-
-          if (this.profileVisible && !profile.contains(event.target)) {
-            this.profileVisible = false;
-          }
-
-
-          if (this.menuVisible) { this.menuVisible = false; }
-        });
-      }
+      document.addEventListener('click', this.handleClickOutside);
+    },
+    destroyed() {
+      document.removeEventListener('click', this.handleClickOutside);
     },
     methods: {
       ...mapActions('user', [
@@ -154,6 +144,17 @@
       openSignOnWith(comp) {
         this.activeSignOnComponent = comp;
         this.signOnVisible = true;
+      },
+      handleClickOutside(event) {
+        event.stopPropagation();
+
+        const { profile } = this.$refs;
+
+        if (this.profileVisible && !profile.contains(event.target)) {
+          this.profileVisible = false;
+        }
+
+        if (this.menuVisible) { this.menuVisible = false; }
       },
     },
   };

--- a/src/packs/main.js
+++ b/src/packs/main.js
@@ -4,7 +4,6 @@ import Rollbar from 'vue-rollbar';
 import { Loading } from 'element-ui';
 import VueTippy from 'vue-tippy';
 import VueScrollTo from 'vue-scrollto';
-import VClickOutside from 'v-click-outside';
 import Meta from 'vue-meta';
 import Home from '@/views/Home.vue';
 import '@/plugins/element.js';
@@ -19,7 +18,6 @@ import store from '@/store/index';
 
 Vue.config.productionTip = false;
 
-Vue.use(VClickOutside);
 Vue.use(VueScrollTo);
 Vue.use(Meta);
 Vue.use(VueTippy, {

--- a/yarn.lock
+++ b/yarn.lock
@@ -10835,11 +10835,6 @@ uuid@^3.3.2, uuid@^3.4.0:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
 
-v-click-outside@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/v-click-outside/-/v-click-outside-3.0.1.tgz#95870c199726069f4eda7eb5781ade62526dd269"
-  integrity sha512-FITcAM0R3JEPUSGiO7hfhKDODZHkOQTk/FyI9mwxNcz6LbMbJhABhjevLI5VsU00PRksloQx8vmpFIqlAfX6nw==
-
 v8-compile-cache@^2.0.3:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.1.0.tgz#e14de37b31a6d194f5690d67efc4e7f6fc6ab30e"


### PR DESCRIPTION
![](https://user-images.githubusercontent.com/4270980/83247612-a6e13000-a19b-11ea-9924-929cf9dacd6a.png)

After a user logs out, there would be an error in the console, for every click, due to the event listener for profile menu off-click, being still present. This PR adds a `destroyed` hook to remove that `EventListener`