### PR TITLE
Password endpoint changes

### DIFF
--- a/src/services/endpoints/auth/passwords.js
+++ b/src/services/endpoints/auth/passwords.js
@@ -1,4 +1,4 @@
-import { plain } from '@/modules/axios';
+import { plain, secure } from '@/modules/axios';
 
 const baseURL = '/auth/passwords';
 
@@ -7,8 +7,19 @@ export const create = (email) => plain
   .then((request) => request)
   .catch((request) => request.response);
 
-export const update = (user, resetPasswordToken) => plain
-  .put(baseURL, { user, reset_password_token: resetPasswordToken })
+export const update = (user) => secure
+  .put(baseURL, {
+    user: {
+      password: user.password,
+      password_confirmation: user.passwordConfirmation,
+      current_password: user.currentPassword,
+    },
+  })
+  .then((request) => request)
+  .catch((request) => request.response);
+
+export const reset = (user, resetPasswordToken) => plain
+  .put(`${baseURL}/reset`, { user, reset_password_token: resetPasswordToken })
   .then((request) => request)
   .catch((request) => request.response);
 

--- a/src/views/ResetPassword.vue
+++ b/src/views/ResetPassword.vue
@@ -46,7 +46,7 @@
   import { Form, FormItem, Input, Message } from 'element-ui';
   import { mapGetters, mapMutations } from 'vuex';
 
-  import { edit, update } from '@/services/endpoints/auth/passwords';
+  import { edit, reset } from '@/services/endpoints/auth/passwords';
 
   export default {
     components: {
@@ -121,7 +121,7 @@
         });
       },
       async submitNewPassword() {
-        const response = await update(this.user, this.resetPasswordToken);
+        const response = await reset(this.user, this.resetPasswordToken);
 
         if (response.status === 200) {
           this.setCurrentUser({

--- a/tests/services/endpoints/auth/passwords.spec.js
+++ b/tests/services/endpoints/auth/passwords.spec.js
@@ -39,24 +39,65 @@ describe('confirmations', () => {
 
     beforeEach(() => {
       updateSpy = jest.spyOn(axios, 'put');
-      user = { id: 1 };
+      user = {
+        id: 1,
+        password: 'new-password',
+        passwordConfirmation: 'new-password',
+        currentPassword: 'password',
+      };
     });
 
-    it('makes a request to the resource and returns request', async () => {
+    it('makes a request to the resource and returns response', async () => {
       updateSpy.mockResolvedValue({ status: 200 });
 
-      const successful = await resource.update(user, 'token');
+      const successful = await resource.update(user);
 
       expect(successful.status).toBe(200);
       expect(updateSpy).toHaveBeenCalledWith(
-        '/auth/passwords', { user, reset_password_token: 'token' }
+        '/auth/passwords',
+        {
+          user: {
+            password: 'new-password',
+            password_confirmation: 'new-password',
+            current_password: 'password',
+          },
+        }
       );
     });
 
     it('makes a request to the resource and returns response if failed', async () => {
       updateSpy.mockRejectedValue({ response: { status: 500 } });
 
-      const successful = await resource.update(user, '');
+      const successful = await resource.update({});
+
+      expect(successful.status).toBe(500);
+    });
+  });
+
+  describe('reset()', () => {
+    let user;
+    let resetSpy;
+
+    beforeEach(() => {
+      resetSpy = jest.spyOn(axios, 'put');
+      user = { id: 1 };
+    });
+
+    it('makes a request to the resource and returns response', async () => {
+      resetSpy.mockResolvedValue({ status: 200 });
+
+      const successful = await resource.reset(user, 'token');
+
+      expect(successful.status).toBe(200);
+      expect(resetSpy).toHaveBeenCalledWith(
+        '/auth/passwords/reset', { user, reset_password_token: 'token' }
+      );
+    });
+
+    it('makes a request to the resource and returns response if failed', async () => {
+      resetSpy.mockRejectedValue({ response: { status: 500 } });
+
+      const successful = await resource.reset(user, '');
 
       expect(successful.status).toBe(500);
     });

--- a/tests/views/ResetPassword.spec.js
+++ b/tests/views/ResetPassword.spec.js
@@ -130,12 +130,12 @@ describe('ResetPassword.vue', () => {
     });
   });
 
-  describe('when updating the password', () => {
+  describe('when reseting the password', () => {
     let router;
-    let updatePasswordSpy;
+    let resetPasswordSpy;
 
     beforeEach(() => {
-      updatePasswordSpy = jest.spyOn(resource, 'update');
+      resetPasswordSpy = jest.spyOn(resource, 'reset');
       router = new VueRouter({
         routes: [{ path: '/manga-list', name: 'manga-list' }],
       });
@@ -176,7 +176,7 @@ describe('ResetPassword.vue', () => {
 
         const user = { user_id: 1, email: 'test1@example.com' };
 
-        updatePasswordSpy.mockResolvedValue({ status: 200, data: user });
+        resetPasswordSpy.mockResolvedValue({ status: 200, data: user });
 
         resetPassword.find({ ref: 'resetPasswordSubmit' }).trigger('click');
 
@@ -201,7 +201,7 @@ describe('ResetPassword.vue', () => {
 
         const errorMessageSpy = jest.spyOn(Message, 'error');
 
-        updatePasswordSpy.mockResolvedValue(
+        resetPasswordSpy.mockResolvedValue(
           { status: 500, data: { error: 'Wrong user' } }
         );
 


### PR DESCRIPTION
This reflects the API endpoint changes, where `reset` is reserved for resetting password functionality, while `update` is reserved for updating user password through settings page