### PR TITLE
Add tags creator

### DIFF
--- a/src/components/settings/SettingsMangaListTags.vue
+++ b/src/components/settings/SettingsMangaListTags.vue
@@ -1,11 +1,222 @@
 <template lang="pug">
-  .bg-white.shadow.px-4.py-5.rounded-lg.sm_p-6
-    .md_grid.md_grid-cols-3.md_gap-6
-      .md_col-span-1
-        h3.text-lg.font-medium.leading-6.text-gray-900 Tags
-          base-badge.ml-3(text="In Development")
+  .bg-white.rounded-lg.shadow(v-loading="tagsLoading")
+    .bg-white.px-4.py-5.border-b.border-gray-200.sm_px-6.rounded-t-lg
+      .-ml-4.-mt-2.flex.items-center.justify-between.flex-wrap.sm_flex-no-wrap
+        .ml-4.mt-2
+          h3.text-lg.leading-6.font-medium.text-gray-900
+            | Tags
+        .ml-4.mt-2.flex-shrink-0
+          span.inline-flex.rounded-md.shadow-sm
+            base-button(ref="openTagCreationModal" @click="modalVisible = true")
+              | Add
+    ul
+      template(v-if="tags.length")
+        li.flex.items-center.px-4.py-4.sm_px-6(
+          v-for="(tag, index) in currentPageTags"
+          :key="tag.id"
+          :class="{ 'border-t border-gray-200': index !== 0 }"
+        )
+          .min-w-0.flex-1.flex.items-center
+            .min-w-0.flex-1.items-center.grid.grid-col-1.space-y-4.sm_space-y-0.sm_grid-cols-4.sm_gap-4
+              div.col-span-1
+                base-badge.float-left(:text="tag.name")
+              .col-span-2.text-sm.leading-5.text-gray-500
+                span(v-if="tag.description" v-text="tag.description")
+                span(v-else) No description
+              .col-span-1.text-sm.leading-5.text-gray-500
+                span.font-bold(v-text="tag.entryCount")
+                |  manga entries
+          base-dropdown(
+            :items="dropdownItems"
+            size="lg"
+            @click="handleClick($event, tag)"
+          )
+      template(v-else)
+        li.flex.justify-center.px-4.py-4.sm_px-6
+          span.text-gray-500
+            | No tags added yet
+    nav.px-4.py-3.flex.items-center.justify-between.border-t.border-gray-200.sm_px-6(v-if="pages > 1")
+      .hidden(class='sm_block')
+        p.text-sm.leading-5.text-gray-700
+          span.font-medium
+          | Total {{ tags.length }} tags
+      .flex.flex-initial.justify-between.sm_justify-end
+        base-button(
+          type="secondary"
+          :disabled="currentPage - 1 === 0"
+          @click="currentPage -= 1"
+        ) Previous
+        base-button.ml-3(
+          type="secondary"
+          :disabled="currentPage + 1 > pages"
+          @click="currentPage += 1"
+        ) Next
+    base-modal(
+      :visible="modalVisible"
+      :loading="modalLoading"
+      size="sm"
+      @dialogClosed="closeModal()"
+    )
+      template(slot='body')
+        .flex.flex-col.w-full
+          .mt-3.text-center.sm_mt-0.sm_text-left.w-full
+            label.block.text-sm.font-medium.leading-5.text-gray-700(for='name')
+              | Name
+            .mt-1.relative.rounded-md.shadow-sm
+              input#name.form-input.block.w-full.sm_text-sm.sm_leading-5(
+                aria-label='Name'
+                name='name'
+                v-model.trim="form.name"
+                placeholder='Isekai'
+                maxlength="50"
+              )
+          .mt-6.text-center.sm_text-left.w-full
+            label.block.text-sm.font-medium.leading-5.text-gray-700(for='description')
+              | Description
+            .mt-1.relative.rounded-md.shadow-sm
+              .max-w-lg.flex.rounded-md.shadow-sm
+              input#description.form-input.block.w-full.sm_text-sm.sm_leading-5(
+                aria-label='Description'
+                name='description'
+                v-model.trim="form.description"
+                placeholder='Protagonist ends up in another world'
+                maxlength="100"
+              )
+      template(slot='actions')
+        span.flex.w-full.rounded-md.shadow-sm.sm_ml-3.sm_w-auto
+          base-button(ref="addTagButton" @click="upsertTag")
+            | Add
+        span.mt-3.flex.w-full.rounded-md.shadow-sm.sm_mt-0.sm_w-auto
+          base-button(type="secondary" @click="closeModal()") Cancel
 </template>
 
 <script>
-  export default {};
+  import { Message } from 'element-ui';
+
+  import {
+    index, create, update, destroy,
+  } from '@/services/endpoints/UserTags.js';
+
+  export default {
+    data() {
+      return {
+        currentPage: 1,
+        tagsPerPage: 5,
+        tagsLoading: false,
+        modalLoading: false,
+        modalVisible: false,
+        dropdownItems: [
+          { text: 'Edit', icon: 'IconEdit' },
+          { text: 'Delete', icon: 'IconTrash' },
+        ],
+        form: { id: null, name: '', description: '' },
+        tags: [],
+      };
+    },
+    computed: {
+      pages() {
+        return Math.ceil(this.tags.length / this.tagsPerPage);
+      },
+      currentPageTags() {
+        const page = this.currentPage - 1;
+        return this.tags.slice(
+          page * this.tagsPerPage,
+          (page + 1) * this.tagsPerPage
+        );
+      },
+    },
+    watch: {
+      pages(newVal) {
+        if (this.currentPage > newVal) { this.currentPage -= 1; }
+      },
+    },
+    async created() {
+      await this.getTags();
+    },
+    methods: {
+      async getTags() {
+        this.tagsLoading = true;
+
+        const response = await index();
+        const { data, status } = response;
+
+        if (status === 200) {
+          this.tags = data;
+        } else {
+          Message.error('Something went wrong, try refreshing the page');
+        }
+
+        this.tagsLoading = false;
+      },
+      async upsertTag() {
+        this.modalLoading = true;
+
+        const isUpdate = this.form.id !== null;
+
+        const response = isUpdate
+          ? await update(this.form)
+          : await create(this.form);
+
+        const { data, status } = response;
+
+        if (status === 200) {
+          if (isUpdate) {
+            const index = this.tags.findIndex((t) => t.id === this.form.id);
+            this.tags.splice(index, 1, data);
+          } else {
+            this.tags.push(data);
+          }
+
+          this.closeModal();
+        } else {
+          Message.error(data);
+        }
+
+        this.modalLoading = false;
+      },
+      async deleteTag() {
+        this.tagsLoading = true;
+
+        const response = await destroy(this.form.id);
+
+        const { data, status } = response;
+
+        if (status === 200) {
+          this.tags = this.tags.filter((tag) => tag.id !== this.form.id);
+        } else {
+          Message.error(data);
+        }
+
+        this.form.id = null;
+        this.tagsLoading = false;
+      },
+      handleClick(item, tag) {
+        if (item === 'Edit') {
+          this.form.id = tag.id;
+          this.form.name = tag.name;
+          this.form.description = tag.description;
+          this.modalVisible = true;
+        } else if (item === 'Delete') {
+          this.form.id = tag.id;
+          this.deleteTag();
+        }
+      },
+      closeModal() {
+        this.modalVisible = false;
+        this.modalLoading = false;
+        this.form = { id: null, name: '', description: '' };
+      },
+    },
+  };
 </script>
+
+<style media="screen" lang="scss">
+  .mobile-descriptors {
+    @apply block mt-2 flex items-center text-sm leading-5;
+    @apply text-gray-500;
+
+    @screen sm {
+      @apply hidden;
+    }
+  }
+</style>

--- a/src/services/endpoints/UserTags.js
+++ b/src/services/endpoints/UserTags.js
@@ -1,0 +1,20 @@
+import { secure } from '@/modules/axios';
+
+const baseURL = '/api/v1/user_tags';
+
+export const index = () => secure
+  .get(baseURL)
+  .then((response) => response)
+  .catch((request) => request.response);
+export const create = (userTag) => secure
+  .post(baseURL, { user_tag: userTag })
+  .then((response) => response)
+  .catch((request) => request.response);
+export const update = (userTag) => secure
+  .put(`${baseURL}/${userTag.id}`, { user_tag: userTag })
+  .then((response) => response)
+  .catch((request) => request.response);
+export const destroy = (id) => secure
+  .delete(`${baseURL}/${id}`)
+  .then((response) => response)
+  .catch((request) => request.response);

--- a/tests/components/settings/SettingsMangaListTags.spec.js
+++ b/tests/components/settings/SettingsMangaListTags.spec.js
@@ -1,0 +1,296 @@
+import { Message } from 'element-ui';
+import flushPromises from 'flush-promises';
+import MangaListTags from '@/components/settings/SettingsMangaListTags.vue';
+import BaseDropdown from '@/components/base_components/BaseDropdown.vue';
+import * as endpoint from '@/services/endpoints/UserTags';
+
+const localVue = createLocalVue();
+
+// To avoid missing directive Vue warnings
+localVue.directive('loading', true);
+
+describe('SettingsMangaListTags.vue', () => {
+  afterEach(() => { jest.restoreAllMocks(); });
+
+  describe('when mounted', () => {
+    let tagsSpy;
+
+    beforeEach(() => {
+      tagsSpy = jest.spyOn(endpoint, 'index');
+    });
+
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
+    describe('and API returns tags', () => {
+      it('shows list of tags', async () => {
+        tagsSpy.mockResolvedValue({
+          status: 200,
+          data: factories.userTag.buildList(1),
+        });
+
+        const mangaListTags = shallowMount(MangaListTags, { localVue });
+
+        await flushPromises();
+
+        expect(mangaListTags.find('ul').html()).toMatchSnapshot();
+      });
+
+      it('shows No tags added yet without tags', async () => {
+        tagsSpy.mockResolvedValue({ status: 200, data: [] });
+
+        const mangaListTags = shallowMount(MangaListTags, { localVue });
+
+        await flushPromises();
+
+        expect(mangaListTags.text()).toContain('No tags added yet');
+      });
+    });
+
+    describe('and API returns an error', () => {
+      it('shows Something went wrong message', async () => {
+        const errorMessageMock = jest.spyOn(Message, 'error');
+        tagsSpy.mockResolvedValue({ status: 500 });
+
+        shallowMount(MangaListTags, { localVue });
+
+        await flushPromises();
+
+        expect(errorMessageMock).toHaveBeenCalledWith(
+          'Something went wrong, try refreshing the page'
+        );
+      });
+    });
+  });
+
+  describe('when selecting an action for a tag', () => {
+    let mangaListTags;
+
+    const tag1 = factories.userTag.build({ name: 'Tag 1' });
+    const tag2 = factories.userTag.build({ name: 'Tag 2' });
+
+    beforeEach(() => {
+      mangaListTags = shallowMount(MangaListTags, {
+        localVue,
+        data() { return { tags: [tag1, tag2] }; },
+      });
+    });
+
+    describe('and action is Edit', () => {
+      it('shows modal with populated tag details', async () => {
+        await mangaListTags.findAllComponents(BaseDropdown).at(1).vm.$emit(
+          'click', 'Edit'
+        );
+
+        expect(mangaListTags.vm.form.id).toEqual(tag2.id);
+        expect(mangaListTags.vm.form.name).toEqual(tag2.name);
+        expect(mangaListTags.vm.form.description).toEqual(tag2.description);
+        expect(mangaListTags.vm.modalVisible).toBeTruthy();
+      });
+    });
+
+    describe('and action is Delete', () => {
+      it('shows modal with populated tag details', async () => {
+        await mangaListTags.findAllComponents(BaseDropdown).at(1).vm.$emit(
+          'click', 'Delete'
+        );
+
+        expect(mangaListTags.vm.form.id).toEqual(tag2.id);
+      });
+    });
+  });
+
+  describe('when creating a tag', () => {
+    let tagsSpy;
+    let mangaListTags;
+
+    const tag1 = factories.userTag.build({ name: 'Tag 1' });
+
+    beforeEach(() => {
+      tagsSpy = jest.spyOn(endpoint, 'create');
+
+      mangaListTags = mount(MangaListTags, {
+        localVue,
+        data() { return { tags: [tag1] }; },
+      });
+    });
+
+    it('shows tag creation modal', async () => {
+      mangaListTags.find({ ref: 'openTagCreationModal' }).trigger('click');
+
+      expect(mangaListTags.vm.modalVisible).toBeTruthy();
+    });
+
+    describe('and creation is successful', () => {
+      it('adds new tag to the tags list', async () => {
+        const newTag = factories.userTag.build({
+          id: null, name: 'New Tag', description: 'Description',
+        });
+
+        tagsSpy.mockResolvedValue({ status: 200, data: newTag });
+
+        await mangaListTags.find({ ref: 'openTagCreationModal' })
+          .trigger('click');
+        await mangaListTags.setData({ form: newTag });
+
+        mangaListTags.find({ ref: 'addTagButton' }).trigger('click');
+
+        await flushPromises();
+
+        expect(tagsSpy).toHaveBeenCalledWith(newTag);
+        expect(mangaListTags.vm.modalVisible).toBeFalsy();
+        expect(mangaListTags.vm.modalLoading).toBeFalsy();
+        expect(mangaListTags.vm.tags).toEqual([tag1, newTag]);
+        expect(mangaListTags.vm.form).toEqual({
+          id: null,
+          name: '',
+          description: '',
+        });
+      });
+    });
+
+    describe('and creation is unsuccessful', () => {
+      it('shows validation errors', async () => {
+        const errorMessageMock = jest.spyOn(Message, 'error');
+        tagsSpy.mockResolvedValue({ status: 500, data: 'Name exists' });
+
+        await mangaListTags.find({ ref: 'openTagCreationModal' })
+          .trigger('click');
+        await mangaListTags.setData({
+          form: factories.userTag.build({ id: null }),
+        });
+
+        mangaListTags.find({ ref: 'addTagButton' }).trigger('click');
+
+        await flushPromises();
+
+        expect(mangaListTags.vm.modalVisible).toBeTruthy();
+        expect(mangaListTags.vm.modalLoading).toBeFalsy();
+        expect(errorMessageMock).toHaveBeenCalledWith('Name exists');
+      });
+    });
+  });
+
+  describe('when updating a tag', () => {
+    let tagsSpy;
+    let mangaListTags;
+
+    const tag1 = factories.userTag.build({ name: 'Tag 1' });
+    const tag2 = factories.userTag.build({ name: 'Tag 2' });
+
+    beforeEach(() => {
+      tagsSpy = jest.spyOn(endpoint, 'update');
+
+      mangaListTags = mount(MangaListTags, {
+        localVue,
+        data() { return { tags: [tag1, tag2], modalVisible: true }; },
+      });
+    });
+
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
+    describe('and update is successful', () => {
+      it('updates tag data', async () => {
+        const updatedTag = factories.userTag.build({
+          id: tag1.id, name: 'New Tag', description: '',
+        });
+
+        tagsSpy.mockResolvedValue({ status: 200, data: updatedTag });
+
+        await mangaListTags.setData({ form: updatedTag });
+
+        mangaListTags.find({ ref: 'addTagButton' }).trigger('click');
+
+        await flushPromises();
+
+        expect(mangaListTags.vm.modalVisible).toBeFalsy();
+        expect(mangaListTags.vm.modalLoading).toBeFalsy();
+        expect(mangaListTags.vm.tags).toEqual([
+          updatedTag,
+          tag2,
+        ]);
+        expect(mangaListTags.vm.form).toEqual({
+          id: null,
+          name: '',
+          description: '',
+        });
+      });
+    });
+
+    describe('and update is unsuccessful', () => {
+      it('shows validation errors', async () => {
+        const errorMessageMock = jest.spyOn(Message, 'error');
+        tagsSpy.mockResolvedValue({ status: 500, data: 'Name exists' });
+
+        await mangaListTags.setData({ form: factories.userTag.build() });
+
+        mangaListTags.find({ ref: 'addTagButton' }).trigger('click');
+
+        await flushPromises();
+
+        expect(mangaListTags.vm.modalVisible).toBeTruthy();
+        expect(mangaListTags.vm.modalLoading).toBeFalsy();
+        expect(errorMessageMock).toHaveBeenCalledWith('Name exists');
+      });
+    });
+  });
+
+  describe('when deleting a tag', () => {
+    let tagsSpy;
+    let mangaListTags;
+
+    const tag1 = factories.userTag.build();
+    const tag2 = factories.userTag.build();
+
+    beforeEach(() => {
+      tagsSpy = jest.spyOn(endpoint, 'destroy');
+
+      mangaListTags = mount(MangaListTags, {
+        localVue,
+        data() { return { tags: [tag1, tag2] }; },
+      });
+    });
+
+    afterEach(() => {
+      expect(tagsSpy).toHaveBeenCalledWith(tag2.id);
+      expect(mangaListTags.vm.form).toEqual({
+        id: null,
+        name: '',
+        description: '',
+      });
+    });
+
+    describe('and deletion is successful', () => {
+      it('removes tag from tags list', async () => {
+        tagsSpy.mockResolvedValue({ status: 200 });
+
+        await mangaListTags.findAllComponents(BaseDropdown).at(1).vm.$emit(
+          'click', 'Delete'
+        );
+
+        await flushPromises();
+
+        expect(mangaListTags.vm.tags).toEqual([tag1]);
+      });
+    });
+
+    describe('and deletion is unsuccessful', () => {
+      it('shows validation errors', async () => {
+        const errorMessageMock = jest.spyOn(Message, 'error');
+
+        tagsSpy.mockResolvedValue({ status: 500, data: 'Not your tag' });
+
+        await mangaListTags.findAllComponents(BaseDropdown).at(1).vm.$emit(
+          'click', 'Delete'
+        );
+
+        await flushPromises();
+
+        expect(errorMessageMock).toHaveBeenCalledWith('Not your tag');
+      });
+    });
+  });
+});

--- a/tests/components/settings/__snapshots__/SettingsMangaListTags.spec.js.snap
+++ b/tests/components/settings/__snapshots__/SettingsMangaListTags.spec.js.snap
@@ -1,0 +1,18 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`SettingsMangaListTags.vue when mounted and API returns tags shows list of tags 1`] = `
+<ul>
+  <li class="flex items-center px-4 py-4 sm_px-6">
+    <div class="min-w-0 flex-1 flex items-center">
+      <div class="min-w-0 flex-1 items-center grid grid-col-1 space-y-4 sm_space-y-0 sm_grid-cols-4 sm_gap-4">
+        <div class="col-span-1">
+          <base-badge-stub text="Isekai" type="primary" class="float-left"></base-badge-stub>
+        </div>
+        <div class="col-span-2 text-sm leading-5 text-gray-500"><span>MC ends up in another world</span></div>
+        <div class="col-span-1 text-sm leading-5 text-gray-500"><span class="font-bold">1</span> manga entries</div>
+      </div>
+    </div>
+    <base-dropdown-stub items="[object Object],[object Object]" size="lg"></base-dropdown-stub>
+  </li>
+</ul>
+`;

--- a/tests/factories/UserTag.js
+++ b/tests/factories/UserTag.js
@@ -1,0 +1,8 @@
+import { Factory } from 'fishery';
+
+export default Factory.define(({ sequence }) => ({
+  id: sequence,
+  name: 'Isekai',
+  description: 'MC ends up in another world',
+  entryCount: 1,
+}));

--- a/tests/factories/index.js
+++ b/tests/factories/index.js
@@ -1,7 +1,10 @@
 import { register } from 'fishery';
 import entry from './mangaEntry';
 import list from './mangaList';
+import userTag from './UserTag';
 import source from './mangaSource';
 
 // eslint-disable-next-line import/prefer-default-export
-export const factories = register({ entry, list, source });
+export const factories = register({
+  entry, list, source, userTag,
+});

--- a/tests/services/endpoints/UserTags.spec.js
+++ b/tests/services/endpoints/UserTags.spec.js
@@ -1,0 +1,101 @@
+import axios from 'axios';
+import * as resource from '@/services/endpoints/UserTags';
+
+describe('UserTags', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('index()', () => {
+    it('makes a request to the resource and returns data', async () => {
+      const getMangaSourcesSpy = jest.spyOn(axios, 'get');
+      const data = factories.userTag.buildList(2);
+
+      getMangaSourcesSpy.mockResolvedValue({ status: 200, data });
+
+      const response = await resource.index();
+
+      expect(response.data).toEqual(data);
+      expect(getMangaSourcesSpy).toHaveBeenCalledWith('/api/v1/user_tags');
+    });
+
+    it('makes a request to the resource and returns false if failed', async () => {
+      axios.get.mockRejectedValue({ status: 500 });
+
+      const response = await resource.index();
+      expect(response).toBeFalsy();
+    });
+  });
+
+  describe('create()', () => {
+    it('makes a request to the resource and returns data', async () => {
+      const getMangaSourcesSpy = jest.spyOn(axios, 'post');
+      const data = factories.userTag.build();
+
+      getMangaSourcesSpy.mockResolvedValue({ status: 200, data });
+
+      const response = await resource.create({
+        name: data.name, description: data.description,
+      });
+
+      expect(response.data).toEqual(data);
+      expect(getMangaSourcesSpy).toHaveBeenCalledWith(
+        '/api/v1/user_tags',
+        { user_tag: { name: data.name, description: data.description } }
+      );
+    });
+
+    it('makes a request to the resource and returns false if failed', async () => {
+      axios.post.mockRejectedValue({ status: 500 });
+
+      const response = await resource.create();
+      expect(response).toBeFalsy();
+    });
+  });
+
+  describe('update()', () => {
+    it('makes a request to the resource and returns data', async () => {
+      const getMangaSourcesSpy = jest.spyOn(axios, 'put');
+      const data = factories.userTag.build();
+
+      getMangaSourcesSpy.mockResolvedValue({ status: 200, data });
+
+      const response = await resource.update({
+        id: data.id, name: 'New Tag', description: '',
+      });
+
+      expect(response.data).toEqual(data);
+      expect(getMangaSourcesSpy).toHaveBeenCalledWith(
+        `/api/v1/user_tags/${data.id}`,
+        { user_tag: { id: data.id, name: 'New Tag', description: '' } }
+      );
+    });
+
+    it('makes a request to the resource and returns false if failed', async () => {
+      axios.put.mockRejectedValue({ status: 500 });
+
+      const response = await resource.update({ id: 1 });
+      expect(response).toBeFalsy();
+    });
+  });
+
+  describe('destroy()', () => {
+    it('makes a request to the resource and returns data', async () => {
+      const getMangaSourcesSpy = jest.spyOn(axios, 'delete');
+
+      getMangaSourcesSpy.mockResolvedValue({ status: 200 });
+
+      const response = await resource.destroy(1);
+
+      expect(response.status).toBe(200);
+      expect(getMangaSourcesSpy).toHaveBeenCalledWith('/api/v1/user_tags/1');
+    });
+
+    it('makes a request to the resource and returns false if failed', async () => {
+      axios.delete.mockRejectedValue({ status: 500 });
+
+      const response = await resource.destroy();
+      expect(response).toBeFalsy();
+    });
+  });
+});


### PR DESCRIPTION
This PR brings the Tags Editor to the Settings page. Here you can add, edit or remove custom tags, to be applied to Manga Entries. It will also showcase how many manga entries has the tag set

![](https://user-images.githubusercontent.com/4270980/85227520-f818c400-b3d5-11ea-857b-de727e30d5b7.gif)