### PR TITLE
Return promise, even if token refresh failed

### DIFF
--- a/src/modules/axios.js
+++ b/src/modules/axios.js
@@ -50,6 +50,8 @@ secure.interceptors.response.use(null, (error) => {
         delete localStorage.vuex;
 
         window.location.reload(true);
+
+        return plain.request(error.response.config);
       });
   }
   return Promise.reject(error);


### PR DESCRIPTION
Because I wasn't returning this promise, catch would get an undefined response, causing the error. Window refresh  
is much slower, so while it didn't affect the user, it had lots of false positive errors in my logs