### PR TITLE
Improve edit entries functionality

### DIFF
--- a/src/components/manga_entries/EditMangaEntries.vue
+++ b/src/components/manga_entries/EditMangaEntries.vue
@@ -11,7 +11,7 @@
           label.block.text-sm.leading-5.font-medium.text-gray-700
             | Status
           .mt-1.relative.rounded-md.shadow-sm.w-auto
-            el-select.rounded.w-full.mt-3(v-model="selectedStatus")
+            el-select.rounded.w-full(v-model="selectedStatus")
               el-option(
                 v-for="status in statuses"
                 :key="status.enum"
@@ -22,7 +22,7 @@
           label.block.text-sm.leading-5.font-medium.text-gray-700
             | Manga Source Name
           .mt-1.relative.rounded-md.shadow-sm.w-auto
-            el-select.rounded.w-full.mt-3(
+            el-select.rounded.w-full(
               v-model="mangaSourceID"
               placeholder="Select new source"
               :disabled="loadingSources"

--- a/src/components/manga_entries/EditMangaEntries.vue
+++ b/src/components/manga_entries/EditMangaEntries.vue
@@ -3,7 +3,7 @@
     :visible="visible"
     :loading="loading"
     size="sm"
-    @dialogClosed="$emit('cancelEdit')"
+    @dialogClosed="$emit('editComplete')"
   )
     template(slot='body')
       .flex.flex-col.w-full
@@ -43,7 +43,7 @@
         )
           | Update
       span.mt-3.sm_mt-0.flex.w-full.rounded-md.shadow-sm.sm_w-auto
-        base-button(type="secondary" @click="$emit('cancelEdit')") Cancel
+        base-button(type="secondary" @click="$emit('editComplete')") Cancel
 </template>
 
 <script>

--- a/src/components/manga_entries/EditMangaEntries.vue
+++ b/src/components/manga_entries/EditMangaEntries.vue
@@ -93,10 +93,18 @@
     },
     watch: {
       selectedEntries(entries, oldEntries) {
-        if (entries.length && entries !== oldEntries && !this.isBulkUpdate) {
-          this.loadAvailableSources();
-          this.selectedStatus = this.selectedEntry.attributes.status;
+        if (entries.length) {
+          if (entries !== oldEntries && !this.isBulkUpdate) {
+            this.selectedStatus = this.selectedEntry.attributes.status;
+          }
+        } else {
+          this.availableSources = [];
+          this.mangaSourceID = null;
+          this.selectedStatus = 1;
         }
+      },
+      visible(val) {
+        if (val && !this.isBulkUpdate) { this.loadAvailableSources(); }
       },
     },
     methods: {

--- a/src/views/MangaList.vue
+++ b/src/views/MangaList.vue
@@ -82,7 +82,6 @@
         ref='editMangaEntryModal'
         :visible='editDialogVisible'
         :selectedEntries='selectedEntries'
-        @cancelEdit='editDialogVisible = false'
         @editComplete="resetEntries('editDialogVisible')"
       )
       delete-manga-entries(

--- a/tests/components/manga_entries/EditMangaEntries.spec.js
+++ b/tests/components/manga_entries/EditMangaEntries.spec.js
@@ -45,23 +45,49 @@ describe('EditMangaEntries.vue', () => {
         });
       });
 
+      describe('when single entry selected', () => {
+        it('prefills status', async () => {
+          await editMangaEntries.setProps({ selectedEntries: [entry1] });
 
-      it('prefills status', async () => {
-        await editMangaEntries.setProps({ selectedEntries: [entry1] });
+          expect(editMangaEntries.vm.$data.selectedStatus).toEqual(
+            entry1.attributes.status
+          );
+        });
+      });
 
-        expect(editMangaEntries.vm.$data.selectedStatus).toEqual(
-          entry1.attributes.status
-        );
+      describe('when entry deselected', () => {
+        it('resets data', async () => {
+          await editMangaEntries.setProps({ selectedEntries: [entry1] });
+          await editMangaEntries.setProps({ selectedEntries: [] });
+          
+          expect(editMangaEntries.vm.selectedStatus).toEqual(1);
+          expect(editMangaEntries.vm.availableSources).toEqual([]);
+          expect(editMangaEntries.vm.mangaSourceID).toEqual(null);
+        });
+      });
+    });
+
+    describe(':visible', () => {
+      let editMangaEntries;
+
+      beforeEach(() => {
+        editMangaEntries = shallowMount(EditMangaEntries, {
+          store,
+          localVue,
+          propsData: { selectedEntries: [entry1] },
+        });
       });
 
       describe('when single entry selected', () => {
         it('loads available sources', async () => {
           const availableSources = factories.source.buildList(1);
-          const getMangaSourcesSpy = jest.spyOn(mangaSources, 'getMangaSources');
+          const getMangaSourcesSpy = jest.spyOn(
+            mangaSources, 'getMangaSources'
+          );
 
           getMangaSourcesSpy.mockResolvedValue({ data: availableSources });
 
-          editMangaEntries.setProps({ selectedEntries: [entry1] });
+          editMangaEntries.setProps({ visible: true });
 
           await flushPromises();
 
@@ -73,11 +99,13 @@ describe('EditMangaEntries.vue', () => {
 
         it("shows error when available sources didn't load", async () => {
           const errorMessageMock = jest.spyOn(Message, 'error');
-          const getMangaSourcesSpy = jest.spyOn(mangaSources, 'getMangaSources');
+          const getMangaSourcesSpy = jest.spyOn(
+            mangaSources, 'getMangaSources'
+          );
 
           getMangaSourcesSpy.mockResolvedValue(false);
 
-          editMangaEntries.setProps({ selectedEntries: [entry1] });
+          editMangaEntries.setProps({ visible: true });
 
           await flushPromises();
 

--- a/tests/views/MangaList.spec.js
+++ b/tests/views/MangaList.spec.js
@@ -129,14 +129,6 @@ describe('MangaList.vue', () => {
     });
 
     describe('@events', () => {
-      it('@cancelEdit - closes edit manga entries dialog', async () => {
-        await mangaList.setData({ editDialogVisible: true });
-
-        mangaList.find(EditMangaEntries).vm.$emit('cancelEdit');
-
-        expect(mangaList.vm.$data.editDialogVisible).toBeFalsy();
-      });
-
       it('@editComplete - resets selected manga entries and closes modal', async () => {
         await mangaList.setData({ editDialogVisible: true });
 


### PR DESCRIPTION
This PR makes some improvements to the Edit entries functionality:

1.  Makes sure to fetch availableSources only when edit modal is open
2.  Correctly reset data on the editModal, when entries are deselected (before they lingered and introduced side-effects)
3.  Improve margins on labels, to match those of TailwindUI