### PR TITLE
Tell users if MangaDex MDList is set to private

### DIFF
--- a/src/components/base_components/BaseActionCompleted.vue
+++ b/src/components/base_components/BaseActionCompleted.vue
@@ -1,16 +1,8 @@
 <template lang="pug">
-  #action-completed
+  .w-full#action-completed
     div
-      .mx-auto.flex.items-center.justify-center.h-12.w-12.rounded-full.bg-green-100
-        svg.h-6.w-6.text-green-600.stroke-current(
-          fill='none'
-          viewbox='0 0 24 24'
-        )
-          path(
-            stroke-linecap='round'
-            stroke-linejoin='round'
-            stroke-width='2' d='M5 13l4 4L19 7'
-          )
+      .icon(:class="classes")
+        component.h-6.w-6(:is="iconName")
       .mt-3.text-center.sm_mt-5
         h3.text-lg.leading-6.font-medium.text-gray-900(v-text="header")
         .mt-2
@@ -28,6 +20,10 @@
         type: String,
         required: true,
       },
+      type: {
+        type: String,
+        default: 'success',
+      },
       text: {
         type: String,
         required: true,
@@ -37,5 +33,25 @@
         required: true,
       },
     },
+    computed: {
+      classes() {
+        return {
+          'bg-green-100 text-green-600': this.type === 'success',
+          'bg-red-100 text-red-600': this.type === 'danger',
+        };
+      },
+      iconName() {
+        return {
+          success: 'icon-check',
+          danger: 'icon-warning',
+        }[this.type];
+      },
+    },
   };
 </script>
+
+<style media="screen" lang="scss" scoped>
+  .icon {
+    @apply mx-auto flex items-center justify-center h-12 w-12 rounded-full;
+  }
+</style>

--- a/src/components/icons/IconCheck.vue
+++ b/src/components/icons/IconCheck.vue
@@ -1,0 +1,9 @@
+<template lang="pug">
+  svg.stroke-current(fill='none' viewbox='0 0 24 24')
+    path(
+      stroke-linecap='round'
+      stroke-linejoin='round'
+      stroke-width='2'
+      d='M5 13l4 4L19 7'
+    )
+</template>

--- a/src/services/endpoints/importers.js
+++ b/src/services/endpoints/importers.js
@@ -1,8 +1,13 @@
 import { secure } from '@/modules/axios';
 
-/* eslint-disable import/prefer-default-export */
+const baseURL = '/api/v1/importers';
+
 export const postTrackrMoe = (filteredLists) => secure
   .post('/api/v1/importers/trackr_moe', { lists: filteredLists })
-  .then(() => true)
-  .catch(() => false);
-/* eslint-enable import/prefer-default-export */
+  .then((response) => response)
+  .catch((request) => request.response);
+
+export const postMDList = (url) => secure
+  .post(`${baseURL}/mangadex`, { url })
+  .then((response) => response)
+  .catch((request) => request.response);

--- a/tests/services/endpoints/importers.spec.js
+++ b/tests/services/endpoints/importers.spec.js
@@ -7,18 +7,47 @@ describe('importers', () => {
   });
 
   describe('postTrackrMoe()', () => {
-    it('makes a request to the resource and returns true', async () => {
-      axios.post.mockResolvedValue({ status: 200 });
+    it('makes a request to the resource and returns response', async () => {
+      const postTrackrMoeSpy = jest.spyOn(axios, 'post');
 
-      const successful = await resource.postTrackrMoe({ lists: {} });
+      axios.post.mockResolvedValue({ status: 200, data: 'Success' });
 
-      expect(successful).toBeTruthy();
+      const response = await resource.postTrackrMoe({});
+
+      expect(response.data).toEqual('Success');
+      expect(postTrackrMoeSpy).toHaveBeenLastCalledWith(
+        '/api/v1/importers/trackr_moe',
+        { lists: {} }
+      );
     });
 
-    it('makes a request to the resource and returns false if failed', async () => {
+    it('makes a request to the resource and returns response if failed', async () => {
       axios.post.mockRejectedValue({ status: 500 });
 
       const successful = await resource.postTrackrMoe({ lists: {} });
+      expect(successful).toBeFalsy();
+    });
+  });
+
+  describe('postMDList()', () => {
+    it('makes a request to the resource and returns response', async () => {
+      const postMDListSpy = jest.spyOn(axios, 'post');
+
+      postMDListSpy.mockResolvedValue({ status: 200, data: 'Good work' });
+
+      const response = await resource.postMDList('mdlist.example/list/1');
+
+      expect(response.data).toEqual('Good work');
+      expect(postMDListSpy).toHaveBeenLastCalledWith(
+        '/api/v1/importers/mangadex',
+        { url: 'mdlist.example/list/1' }
+      );
+    });
+
+    it('makes a request to the resource and returns error response if failed', async () => {
+      axios.post.mockRejectedValue({ status: 500 });
+
+      const successful = await resource.postMDList('');
       expect(successful).toBeFalsy();
     });
   });


### PR DESCRIPTION
MangaDex accounts by default set the MDList to private. So many users end up getting an email, saying they need to make the account public. They also have to refresh the page, so submit the URL again. All of that is not good UX.

This PR fixes it, by immediately telling the user, if the list is private (or if something else goes wrong) and then closing the modal, resets it's status so that users can submit it the URL again, without having to refresh the page

<table><tbody><tr><td>Private List</td><td>Import had an unexpected error</td></tr><tr><td><figure class="image"><img src="https://user-images.githubusercontent.com/4270980/87245485-9203e780-c43d-11ea-8034-6c0b1694066b.png"></figure></td><td><figure class="image"><img src="https://user-images.githubusercontent.com/4270980/87245486-9203e780-c43d-11ea-8a6b-d5e48c6945c7.png"></figure></td></tr></tbody></table>