### PR TITLE
Handle new response type during import

### DIFF
--- a/src/components/TheImporters.vue
+++ b/src/components/TheImporters.vue
@@ -112,6 +112,10 @@
           this.completedActionHeader = 'Import started';
           this.type = 'success';
           this.completedActionText = response.data;
+        } else if (response.status === 400) {
+          this.completedActionHeader = 'Import currently in progress';
+          this.type = 'danger';
+          this.completedActionText = response.data;
         } else if (response.status === 404) {
           this.completedActionHeader = 'List is private';
           this.type = 'danger';
@@ -145,6 +149,10 @@
         if (response.status === 200) {
           this.completedActionHeader = 'Import started';
           this.type = 'success';
+          this.completedActionText = response.data;
+        } else if (response.status === 400) {
+          this.completedActionHeader = 'Import currently in progress';
+          this.type = 'danger';
           this.completedActionText = response.data;
         } else {
           this.completedActionHeader = 'Something went wrong';

--- a/tests/components/TheImporters.spec.js
+++ b/tests/components/TheImporters.spec.js
@@ -123,39 +123,63 @@ describe('TheImporters.vue', () => {
         expect(fileReaderReadTextMock).toHaveBeenCalled();
       });
 
-      it('shows success message', async () => {
-        const postTrackrMoeMock = jest.spyOn(
-          importersEndpoint, 'postTrackrMoe'
-        );
+      describe('and request status is success', () => {
+        it('shows success message', async () => {
+          const postTrackrMoeMock = jest.spyOn(
+            importersEndpoint, 'postTrackrMoe'
+          );
 
-        postTrackrMoeMock.mockResolvedValue({
-          status: 200,
-          data: 'You will receive an email',
+          postTrackrMoeMock.mockResolvedValue({
+            status: 200,
+            data: 'You will receive an email',
+          });
+
+          importers.vm.processMangaDexList(importedList);
+
+          await flushPromises();
+
+          expect(importers.text()).toContain('Import started');
+          expect(importers.text()).toContain('You will receive an email');
         });
-
-        importers.vm.processMangaDexList(importedList);
-
-        await flushPromises();
-
-        expect(importers.text()).toContain('Import started');
-        expect(importers.text()).toContain('You will receive an email');
       });
 
-      it('shows Something went wrong message if import failed', async () => {
-        const postTrackrMoeMock = jest.spyOn(
-          importersEndpoint, 'postTrackrMoe'
-        );
+      describe('and request status is bad request', () => {
+        it('shows that import is currently in progress', async () => {
+          const postTrackrMoeMock = jest.spyOn(
+            importersEndpoint, 'postTrackrMoe'
+          );
 
-        postTrackrMoeMock.mockResolvedValue({ status: 500 });
+          postTrackrMoeMock.mockResolvedValue({
+            status: 400,
+            data: 'Import in progress',
+          });
 
-        importers.vm.processMangaDexList(importedList);
+          importers.vm.processMangaDexList(importedList);
 
-        await flushPromises();
+          await flushPromises();
 
-        expect(importers.text()).toContain('Something went wrong');
-        expect(importers.text()).toContain(
-          'Try again later or contact hi@kenmei.co'
-        );
+          expect(importers.text()).toContain('Import currently in progress');
+          expect(importers.text()).toContain('Import in progress');
+        });
+      });
+
+      describe('and request status is not handled', () => {
+        it('shows Something went wrong message', async () => {
+          const postTrackrMoeMock = jest.spyOn(
+            importersEndpoint, 'postTrackrMoe'
+          );
+
+          postTrackrMoeMock.mockResolvedValue({ status: 500 });
+
+          importers.vm.processMangaDexList(importedList);
+
+          await flushPromises();
+
+          expect(importers.text()).toContain('Something went wrong');
+          expect(importers.text()).toContain(
+            'Try again later or contact hi@kenmei.co'
+          );
+        });
       });
     });
 
@@ -207,6 +231,24 @@ describe('TheImporters.vue', () => {
 
         expect(importers.text()).toContain('Import started');
         expect(importers.text()).toContain('You will receive an email');
+      });
+    });
+
+    describe('and request status is bad request', () => {
+      it('shows that import is currently in progress', async () => {
+        const postMDListSpy = jest.spyOn(importersEndpoint, 'postMDList');
+
+        postMDListSpy.mockResolvedValue({
+          status: 400,
+          data: 'Import in progress',
+        });
+
+        importers.vm.importMangaDex();
+
+        await flushPromises();
+
+        expect(importers.text()).toContain('Import currently in progress');
+        expect(importers.text()).toContain('Import in progress');
       });
     });
 


### PR DESCRIPTION
API will now return an error if you are trying to import a list, while another import is ongoing. This PR makes sure it handles the new response, by displaying the correct error.

![](https://user-images.githubusercontent.com/4270980/89104966-20ec9a00-d415-11ea-85d8-ac0a764d6780.png)