### PR TITLE
Make tags filterable

### DIFF
--- a/src/components/manga_entries/EditMangaEntries.vue
+++ b/src/components/manga_entries/EditMangaEntries.vue
@@ -43,6 +43,7 @@
               placeholder="Select Tags"
               multiple
               collapse-tags
+              filterable
             )
               el-option(
                 v-for="tag in tags"

--- a/src/views/MangaList.vue
+++ b/src/views/MangaList.vue
@@ -21,6 +21,7 @@
           :disabled="tagsLoading"
           multiple
           collapse-tags
+          filterable
         )
           template(slot='empty')
             .relative.p-3.font-normal.text-sm.text-center


### PR DESCRIPTION
A small improvement, which adds the ability to filter tags, when selecting the in the dashboard or in the Edit Manga Entry modal. 

![](https://user-images.githubusercontent.com/4270980/90984339-251b5b80-e56c-11ea-967e-abb4b196a5b3.gif)