### PR TITLE
Purge unused tailwind classes

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -2,6 +2,11 @@ const defaultTheme = require('tailwindcss/defaultTheme');
 
 module.exports = {
   separator: '_',
+  purge: [
+    './src/**/*.html',
+    './src/**/*.vue',
+    './src/**/*.jsx',
+  ],
   theme: {
     screens: {
       sm: '640px',


### PR DESCRIPTION
With built-in PurgeCSS support for Tailwind, this should remove unused tailwind classes, resulting in a massivly small css footprint

> **When building for production, you should always use Tailwind's `purge` option to tree-shake unused styles and optimize your final build size.** When removing unused styles with Tailwind, it's very hard to end up with more than 10kb of compressed CSS.