### PR TITLE
Show volume information

### DIFF
--- a/src/components/TheMangaList.vue
+++ b/src/components/TheMangaList.vue
@@ -56,7 +56,7 @@
           )
       el-table-column(
         prop="attributes.last_chapter_read"
-        label="Last Chapter Read"
+        label="Last Read"
         align="center"
       )
         template(v-if='scope.row.attributes' slot-scope="scope")
@@ -66,12 +66,12 @@
             :underline="false"
             target="_blank"
           )
-            | {{ scope.row.attributes.last_chapter_read }}
+            | {{ chapterInfo(scope.row.attributes.last_volume_read, scope.row.attributes.last_chapter_read) }}
           template(v-else)
-            | {{ scope.row.attributes.last_chapter_read }}
+            | {{ chapterInfo(scope.row.attributes.last_volume_read, scope.row.attributes.last_chapter_read) }}
       el-table-column(
         prop="links.last_chapter_available_url"
-        label="Latest Chapter"
+        label="Last Available"
         align="center"
       )
         template(v-if='scope.row.attributes' slot-scope="scope")
@@ -81,7 +81,7 @@
             :underline="false"
             target="_blank"
           )
-            | {{ scope.row.attributes.last_chapter_available }}
+            | {{ chapterInfo(scope.row.attributes.last_volume_available, scope.row.attributes.last_chapter_available) }}
           template(v-else)
             | No chapters
       el-table-column(
@@ -204,19 +204,31 @@
           1: 'success', 2: 'warning', 3: 'warning-light', 5: 'danger',
         }[status];
       },
+      chapterInfo(volume, chapter) {
+        if (chapter) {
+          if (volume && volume !== '0') { return `Vol. ${volume} Ch. ${chapter}`; }
+
+          return `Ch. ${chapter}`;
+        }
+
+        return '';
+      },
       async setLastRead(entry) {
         this.entryUpdated = entry;
 
         const attributes = {
+          last_volume_read: entry.attributes.last_volume_available,
           last_chapter_read: entry.attributes.last_chapter_available,
           last_chapter_read_url: entry.links.last_chapter_available_url,
         };
 
         const response = await updateMangaEntry(entry.id, attributes);
         if (response) {
-          Message.info(
-            `Updated last read chapter to ${attributes.last_chapter_read}`,
+          const lastRead = this.chapterInfo(
+            attributes.last_volume_read, attributes.last_chapter_read,
           );
+
+          Message.info(`Updated last read to ${lastRead}`);
           this.updateEntry(response);
         } else {
           Message.error("Couldn't update. Try refreshing the page");

--- a/src/views/MangaList.vue
+++ b/src/views/MangaList.vue
@@ -258,6 +258,7 @@
       async updateEntries() {
         const attributes = this.selectedEntries.map((entry) => ({
           id: entry.id,
+          last_volume_read: entry.attributes.last_volume_available,
           last_chapter_read: entry.attributes.last_chapter_available,
           last_chapter_read_url: entry.links.last_chapter_available_url,
         }));

--- a/tests/components/TheMangaList.spec.js
+++ b/tests/components/TheMangaList.spec.js
@@ -57,6 +57,26 @@ describe('TheMangaList.vue', () => {
       expect(rows.at(0).text()).toContain('Reading');
       expect(rows.at(1).text()).toContain('Completed');
     });
+
+    it('displays volume and/or chapter', async () => {
+      const entry1 = factories.entry.build({
+        id: '1', attributes: { last_volume_read: '1' },
+      });
+      const entry2 = factories.entry.build();
+
+      await mangaList.setProps({ tableData: [entry1, entry2] });
+
+      const rows = mangaList.findAll('.el-table__row');
+
+      expect(rows.at(0).text()).toContain(
+        `Vol. ${entry1.attributes.last_volume_read} Ch. ${
+          entry1.attributes.last_chapter_read
+        }`,
+      );
+      expect(rows.at(1).text()).toContain(
+        `Ch. ${entry2.attributes.last_chapter_read}`,
+      );
+    });
   });
 
   describe('when updating a manga entry', () => {
@@ -91,6 +111,7 @@ describe('TheMangaList.vue', () => {
         id: 1,
         attributes: {
           title: 'Manga Title',
+          last_volume_read: '2',
           last_chapter_read: '2',
           last_chapter_available: '2',
         },
@@ -103,7 +124,7 @@ describe('TheMangaList.vue', () => {
       await flushPromises();
 
       expect(infoMessageMock).toHaveBeenCalledWith(
-        'Updated last read chapter to 2',
+        'Updated last read to Ch. 2',
       );
     });
 

--- a/tests/factories/mangaEntry.js
+++ b/tests/factories/mangaEntry.js
@@ -8,7 +8,9 @@ export default Factory.define(({ sequence }) => ({
   attributes: {
     title: 'Manga Title',
     status: 1,
+    last_volume_read: null,
     last_chapter_read: '1',
+    last_volume_available: null,
     last_chapter_available: '2',
     last_released_at: '2019-01-01T00:00:00.000Z',
     tracked_entries: [

--- a/tests/views/MangaList.spec.js
+++ b/tests/views/MangaList.spec.js
@@ -168,7 +168,11 @@ describe('MangaList.vue', () => {
       });
       entry2 = factories.entry.build({
         id: 2,
-        attributes: { last_chapter_read: '3', last_chapter_available: '4' },
+        attributes: {
+          last_chapter_read: '3',
+          last_volume_available: '2',
+          last_chapter_available: '4',
+        },
         links: {
           last_chapter_read_url: 'example.url/chapter/3',
           last_chapter_available_url: 'example.url/chapter/4',
@@ -210,7 +214,7 @@ describe('MangaList.vue', () => {
         }),
         factories.entry.build({
           id: 2,
-          attributes: { last_chapter_read: '4' },
+          attributes: { last_volume_read: '2', last_chapter_read: '4' },
           links: { last_chapter_read_url: 'example.url/chapter/4' },
         }),
       ];
@@ -222,11 +226,13 @@ describe('MangaList.vue', () => {
           {
             id: entry1.id,
             last_chapter_read: entry1.attributes.last_chapter_available,
+            last_volume_read: entry1.attributes.last_volume_available,
             last_chapter_read_url: entry1.links.last_chapter_available_url,
           },
           {
             id: entry2.id,
             last_chapter_read: entry2.attributes.last_chapter_available,
+            last_volume_read: entry2.attributes.last_volume_available,
             last_chapter_read_url: entry2.links.last_chapter_available_url,
           },
         ],


### PR DESCRIPTION
- [x] Need to update all MangaDex sources to have volume information, before merging this in 

With back-end now storing volume information, we can start showing this on the client-side as well. If Last Read or Last Available columns have volume information, it will now be shown.

![image](https://user-images.githubusercontent.com/4270980/91168362-6bd49700-e6cd-11ea-9a28-78e68e29e58e.png)


