### PR TITLE
Use server-side unread field

### DIFF
--- a/src/components/TheMangaList.vue
+++ b/src/components/TheMangaList.vue
@@ -25,7 +25,7 @@
         label-class-name="p-0"
       )
         template(slot-scope="scope")
-          .new-chapter-dot(v-if="unread(scope.row)")
+          .new-chapter-dot(v-if="scope.row.attributes.unread")
       el-table-column(
         prop="attributes.title"
         label="Title"
@@ -108,7 +108,7 @@
           )
           el-button(
             content="Set last read to the latest chapter"
-            v-if="unread(scope.row)"
+            v-if="scope.row.attributes.unread"
             ref="updateEntryButton"
             icon="el-icon-check"
             size="mini"
@@ -137,7 +137,7 @@
   import relativeTime from 'dayjs/plugin/relativeTime';
 
   import { updateMangaEntry } from '@/services/api';
-  import { unread, sortBy } from '@/services/sorters';
+  import { sortBy } from '@/services/sorters';
 
   dayjs.extend(relativeTime);
 
@@ -190,7 +190,6 @@
       },
     },
     methods: {
-      unread,
       ...mapMutations('lists', [
         'updateEntry',
       ]),

--- a/src/services/sorters.js
+++ b/src/services/sorters.js
@@ -15,8 +15,8 @@ const titleSort = (entryA, entryB) => {
 };
 /* eslint-enable camelcase */
 
-const newReleasesSort = (entryA, entryB) => Number(unread(entryB))
-  - Number(unread(entryA));
+const newReleasesSort = (entryA, entryB) => Number(entryB.attributes.unread)
+  - Number(entryA.attributes.unread);
 
 const releasedAtSort = (a, b) => {
   const aReleasedAt = a.attributes.last_released_at;

--- a/src/services/sorters.js
+++ b/src/services/sorters.js
@@ -1,12 +1,4 @@
 /* eslint-disable camelcase */
-export const unread = (entry) => {
-  const { last_chapter_read_url, last_chapter_available_url } = entry.links;
-
-
-  return last_chapter_available_url
-    && last_chapter_read_url !== last_chapter_available_url;
-};
-
 const titleSort = (entryA, entryB) => {
   const entryATitle = entryA.attributes.title.toLowerCase();
   const entryBTitle = entryB.attributes.title.toLowerCase();

--- a/tests/factories/mangaEntry.js
+++ b/tests/factories/mangaEntry.js
@@ -8,6 +8,7 @@ export default Factory.define(({ sequence }) => ({
   attributes: {
     title: 'Manga Title',
     status: 1,
+    unread: true,
     last_volume_read: null,
     last_chapter_read: '1',
     last_volume_available: null,

--- a/tests/services/sorters.spec.js
+++ b/tests/services/sorters.spec.js
@@ -1,4 +1,4 @@
-import { unread, sortBy } from '@/services/sorters';
+import { sortBy } from '@/services/sorters';
 
 describe('Sorters', () => {
   let entry1;
@@ -36,50 +36,6 @@ describe('Sorters', () => {
         },
       },
     );
-  });
-  describe('unread', () => {
-    describe('when last chapter availiable is different than last read', () => {
-      it('returns true', () => {
-        const entry = factories.entry.build(
-          {
-            links: {
-              last_chapter_read_url: 'example.url/manga/1/chapter/4',
-              last_chapter_available_url: 'example.url/manga/1/chapter/5',
-            },
-          },
-        );
-
-        expect(unread(entry)).toBeTruthy();
-      });
-    });
-    describe('when last read null and last released chapter availiable', () => {
-      it('returns true', () => {
-        const entry = factories.entry.build(
-          {
-            links: {
-              last_chapter_read_url: null,
-              last_chapter_available_url: 'example.url/manga/1/chapter/5',
-            },
-          },
-        );
-
-        expect(unread(entry)).toBeTruthy();
-      });
-    });
-    describe('when last available is null', () => {
-      it('returns false', () => {
-        const entry = factories.entry.build(
-          {
-            links: {
-              last_chapter_read_url: 'example.url/manga/1/chapter/5',
-              last_chapter_available_url: null,
-            },
-          },
-        );
-
-        expect(unread(entry)).toBeFalsy();
-      });
-    });
   });
 
   describe('sortBy', () => {


### PR DESCRIPTION
In preparation for the server-side sorting, MangaEntries now contain `unread` fields on the DB level, so that we can correctly make use of DB ordering. This PR replaces client-side logic for deciding if an entry is unread or not, and instead uses the new attribute provided from the API