### PR TITLE
Fix showing titles with Ch.

### DIFF
--- a/src/components/TheMangaList.vue
+++ b/src/components/TheMangaList.vue
@@ -206,7 +206,12 @@
       },
       chapterInfo(volume, chapter) {
         if (chapter) {
+          const chapterNumber = parseFloat(chapter);
+
           if (volume && volume !== '0') { return `Vol. ${volume} Ch. ${chapter}`; }
+
+          // TODO: Replace when we return titles separately from the chapter
+          if (Number.isNaN(chapterNumber)) return chapter;
 
           return `Ch. ${chapter}`;
         }

--- a/tests/components/TheMangaList.spec.js
+++ b/tests/components/TheMangaList.spec.js
@@ -77,6 +77,23 @@ describe('TheMangaList.vue', () => {
         `Ch. ${entry2.attributes.last_chapter_read}`,
       );
     });
+
+    it('displays title if chapter is not present', async () => {
+      const entry1 = factories.entry.build({
+        attributes: {
+          last_chapter_read: 'Oneshot', last_chapter_available: '',
+        },
+      });
+
+      await mangaList.setProps({ tableData: [entry1] });
+
+      const rows = mangaList.findAll('.el-table__row');
+
+      expect(rows.at(0).text()).toContain(
+        `${entry1.attributes.last_chapter_read}`,
+      );
+      expect(rows.at(0).text()).not.toContain('Ch.');
+    });
   });
 
   describe('when updating a manga entry', () => {


### PR DESCRIPTION
Updated template of showing chapters and volumes, would incorrectly display `Ch.` when we return a title, instead of a chapter number. This does a hotfix, by checking if the chapter actually contains a number of not , before deciding how to return it

## Before

![](https://user-images.githubusercontent.com/4270980/93022453-60480200-f5e1-11ea-9e6b-51cf82f69e04.png)

## After

![](https://user-images.githubusercontent.com/4270980/93022443-5a522100-f5e1-11ea-8199-9bf1cbddfbaf.png)