### PR TITLE
Wrong selected sort

### DIFF
--- a/src/views/MangaList.vue
+++ b/src/views/MangaList.vue
@@ -147,7 +147,7 @@
       return {
         selectedEntries: [],
         selectedTagIDs: [],
-        selectedSort: { Unread: 'asc' },
+        selectedSort: { Unread: 'desc' },
         selectedStatus: 1,
         entriesSelected: false,
         searchTerm: '',


### PR DESCRIPTION
While we changed it to `desc` on the SortDropdown, I forgot to change it on the `MangaList` view itself, resulting in incorrect sorting, when switching filters