### PR TITLE
Fix not showing newly added entry

### DIFF
--- a/src/components/manga_entries/AddMangaEntry.vue
+++ b/src/components/manga_entries/AddMangaEntry.vue
@@ -36,7 +36,7 @@
       span.flex.w-full.rounded-md.shadow-sm.sm_ml-3.sm_w-auto
         base-button(
           ref="addMangaButton"
-          @click="mangaDexSearch"
+          @click="addSeriesEntry"
           :disabled="mangaURL.length === 0"
         )
           | Add
@@ -90,35 +90,35 @@
         'addEntry',
         'replaceEntry',
       ]),
-      mangaDexSearch() {
+      async addSeriesEntry() {
         this.loading = true;
 
-        addMangaEntry(this.mangaURL, this.selectedStatus)
-          .then((newMangaEntry) => {
-            const { data } = newMangaEntry;
-            const currentEntry = this.findEntryFromIDs(
-              data.attributes.tracked_entries.map((e) => e.id),
-            );
+        const response = await addMangaEntry(this.mangaURL, this.selectedStatus);
+        const { status, data } = response;
 
-            if (currentEntry) {
-              this.replaceEntry({ currentEntry, newEntry: data });
-            } else {
-              this.addEntry(newMangaEntry.data);
-            }
+        if (status === 200) {
+          const entryData = data.data;
 
-            this.closeModal();
-          })
-          .catch((error) => {
-            const { status, data } = error.response;
+          const currentEntry = this.findEntryFromIDs(
+            entryData.attributes.tracked_entries.map((e) => e.id),
+          );
 
-            if (status === 404 || status === 406) {
-              Message.info(data);
-              this.loading = false;
-            } else {
-              Message.error('Something went wrong');
-              this.closeModal();
-            }
-          });
+          if (currentEntry) {
+            this.replaceEntry({ currentEntry, newEntry: entryData });
+          } else {
+            this.addEntry(entryData);
+          }
+
+          this.closeModal();
+
+          Message.info('New Entry added');
+        } else if (status === 404 || status === 406) {
+          Message.info(data);
+          this.loading = false;
+        } else {
+          Message.error('Something went wrong');
+          this.closeModal();
+        }
       },
       closeModal() {
         this.$emit('dialogClosed');

--- a/src/components/manga_entries/AddMangaEntry.vue
+++ b/src/components/manga_entries/AddMangaEntry.vue
@@ -36,7 +36,7 @@
       span.flex.w-full.rounded-md.shadow-sm.sm_ml-3.sm_w-auto
         base-button(
           ref="addMangaButton"
-          @click="addSeriesEntry"
+          @click="addMangaEntry"
           :disabled="mangaURL.length === 0"
         )
           | Add
@@ -47,7 +47,7 @@
 <script>
   import { mapState, mapMutations, mapGetters } from 'vuex';
   import { Message, Select, Option } from 'element-ui';
-  import { addMangaEntry } from '@/services/api';
+  import { create } from '@/services/api';
 
   export default {
     name: 'AddMangaEntry',
@@ -90,10 +90,10 @@
         'addEntry',
         'replaceEntry',
       ]),
-      async addSeriesEntry() {
+      async addMangaEntry() {
         this.loading = true;
 
-        const response = await addMangaEntry(this.mangaURL, this.selectedStatus);
+        const response = await create(this.mangaURL, this.selectedStatus);
         const { status, data } = response;
 
         if (status === 200) {

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -1,6 +1,6 @@
 import { secure } from '@/modules/axios';
 
-export const addMangaEntry = (seriesURL, status) => secure
+export const create = (seriesURL, status) => secure
   .post('/api/v1/manga_entries/', {
     manga_entry: { series_url: seriesURL, status },
   })

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -4,11 +4,8 @@ export const addMangaEntry = (seriesURL, status) => secure
   .post('/api/v1/manga_entries/', {
     manga_entry: { series_url: seriesURL, status },
   })
-  .then((response) => {
-    if (response.data.error) { return {}; }
-
-    return response.data;
-  });
+  .then((response) => response)
+  .catch((request) => request.response);
 
 export const updateMangaEntry = (id, attributes) => secure
   .put(`/api/v1/manga_entries/${id}`, { manga_entry: attributes })

--- a/src/store/modules/lists.js
+++ b/src/store/modules/lists.js
@@ -59,7 +59,7 @@ const mutations = {
     state.entriesPagy = data;
   },
   addEntry(state, data) {
-    state.entries.push(data);
+    state.entries.unshift(data);
   },
   updateEntry(state, data) {
     state.entries.splice(getEntryIndex(state, data.id), 1, data);

--- a/tests/components/manga_entries/AddMangaEntry.spec.js
+++ b/tests/components/manga_entries/AddMangaEntry.spec.js
@@ -48,7 +48,7 @@ describe('AddMangaEntry.vue', () => {
     });
   });
 
-  describe('when adding new MangaDex entry', () => {
+  describe('when adding new manga entry', () => {
     let addMangaEntrySpy;
 
     beforeEach(() => {
@@ -65,9 +65,11 @@ describe('AddMangaEntry.vue', () => {
       it('adds new Manga entry', async () => {
         const mangaEntry = factories.entry.build();
 
-        addMangaEntrySpy.mockResolvedValue({ data: mangaEntry });
+        addMangaEntrySpy.mockResolvedValue({
+          status: 200, data: { data: mangaEntry },
+        });
 
-        addMangaEntry.vm.mangaDexSearch();
+        addMangaEntry.vm.addSeriesEntry();
 
         await flushPromises();
 
@@ -101,9 +103,11 @@ describe('AddMangaEntry.vue', () => {
           },
         });
 
-        addMangaEntrySpy.mockResolvedValue({ data: newMangaEntry });
+        addMangaEntrySpy.mockResolvedValue({
+          status: 200, data: { data: newMangaEntry },
+        });
 
-        addMangaEntry.vm.mangaDexSearch();
+        addMangaEntry.vm.addSeriesEntry();
 
         await flushPromises();
 
@@ -117,11 +121,11 @@ describe('AddMangaEntry.vue', () => {
       it('shows info message with payload data', async () => {
         const infoMessageMock = jest.spyOn(Message, 'info');
 
-        addMangaEntrySpy.mockRejectedValue(
-          { response: { status: 404, data: 'Manga was not found' } },
+        addMangaEntrySpy.mockResolvedValue(
+          { status: 404, data: 'Manga was not found' },
         );
 
-        addMangaEntry.vm.mangaDexSearch();
+        addMangaEntry.vm.addSeriesEntry();
 
         await flushPromises();
         expect(infoMessageMock).toHaveBeenCalledWith('Manga was not found');
@@ -132,11 +136,11 @@ describe('AddMangaEntry.vue', () => {
       it('shows info message with payload data', async () => {
         const infoMessageMock = jest.spyOn(Message, 'info');
 
-        addMangaEntrySpy.mockRejectedValue(
-          { response: { status: 406, data: 'Manga already added' } },
+        addMangaEntrySpy.mockResolvedValue(
+          { status: 406, data: 'Manga already added' },
         );
 
-        addMangaEntry.vm.mangaDexSearch();
+        addMangaEntry.vm.addSeriesEntry();
 
         await flushPromises();
         expect(infoMessageMock).toHaveBeenCalledWith('Manga already added');
@@ -146,9 +150,9 @@ describe('AddMangaEntry.vue', () => {
     it('shows error message on unsuccessful API lookup', async () => {
       const errorMessageMock = jest.spyOn(Message, 'error');
 
-      addMangaEntrySpy.mockRejectedValue({ response: { status: 500 } });
+      addMangaEntrySpy.mockResolvedValue({ status: 500 });
 
-      addMangaEntry.vm.mangaDexSearch();
+      addMangaEntry.vm.addSeriesEntry();
 
       await flushPromises();
 

--- a/tests/components/manga_entries/AddMangaEntry.spec.js
+++ b/tests/components/manga_entries/AddMangaEntry.spec.js
@@ -49,27 +49,27 @@ describe('AddMangaEntry.vue', () => {
   });
 
   describe('when adding new manga entry', () => {
-    let addMangaEntrySpy;
+    let createEntrySpy;
 
     beforeEach(() => {
       addMangaEntry.setData({ mangaURL: 'example.url/manga/1' });
 
-      addMangaEntrySpy = jest.spyOn(api, 'addMangaEntry');
+      createEntrySpy = jest.spyOn(api, 'create');
     });
 
     afterEach(() => {
-      expect(addMangaEntrySpy).toHaveBeenCalledWith('example.url/manga/1', 1);
+      expect(createEntrySpy).toHaveBeenCalledWith('example.url/manga/1', 1);
     });
 
     describe('when no manga sources are tracked', () => {
       it('adds new Manga entry', async () => {
         const mangaEntry = factories.entry.build();
 
-        addMangaEntrySpy.mockResolvedValue({
+        createEntrySpy.mockResolvedValue({
           status: 200, data: { data: mangaEntry },
         });
 
-        addMangaEntry.vm.addSeriesEntry();
+        addMangaEntry.vm.addMangaEntry();
 
         await flushPromises();
 
@@ -103,11 +103,11 @@ describe('AddMangaEntry.vue', () => {
           },
         });
 
-        addMangaEntrySpy.mockResolvedValue({
+        createEntrySpy.mockResolvedValue({
           status: 200, data: { data: newMangaEntry },
         });
 
-        addMangaEntry.vm.addSeriesEntry();
+        addMangaEntry.vm.addMangaEntry();
 
         await flushPromises();
 
@@ -121,11 +121,11 @@ describe('AddMangaEntry.vue', () => {
       it('shows info message with payload data', async () => {
         const infoMessageMock = jest.spyOn(Message, 'info');
 
-        addMangaEntrySpy.mockResolvedValue(
+        createEntrySpy.mockResolvedValue(
           { status: 404, data: 'Manga was not found' },
         );
 
-        addMangaEntry.vm.addSeriesEntry();
+        addMangaEntry.vm.addMangaEntry();
 
         await flushPromises();
         expect(infoMessageMock).toHaveBeenCalledWith('Manga was not found');
@@ -136,11 +136,11 @@ describe('AddMangaEntry.vue', () => {
       it('shows info message with payload data', async () => {
         const infoMessageMock = jest.spyOn(Message, 'info');
 
-        addMangaEntrySpy.mockResolvedValue(
+        createEntrySpy.mockResolvedValue(
           { status: 406, data: 'Manga already added' },
         );
 
-        addMangaEntry.vm.addSeriesEntry();
+        addMangaEntry.vm.addMangaEntry();
 
         await flushPromises();
         expect(infoMessageMock).toHaveBeenCalledWith('Manga already added');
@@ -150,9 +150,9 @@ describe('AddMangaEntry.vue', () => {
     it('shows error message on unsuccessful API lookup', async () => {
       const errorMessageMock = jest.spyOn(Message, 'error');
 
-      addMangaEntrySpy.mockResolvedValue({ status: 500 });
+      createEntrySpy.mockResolvedValue({ status: 500 });
 
-      addMangaEntry.vm.addSeriesEntry();
+      addMangaEntry.vm.addMangaEntry();
 
       await flushPromises();
 

--- a/tests/services/api.spec.js
+++ b/tests/services/api.spec.js
@@ -7,24 +7,28 @@ describe('API', () => {
   });
 
   describe('addMangaEntry()', () => {
-    it('makes a request to the API and returns manga if found', async () => {
+    it('makes a request to the resource and returns data', async () => {
+      const postMangaEntriesCollectionsSpy = jest.spyOn(axios, 'post');
       const mangaURL = 'example.url/123';
       const status = 1;
-      const mockData = factories.entry.build();
+      const data = factories.entry.build();
 
-      axios.post.mockResolvedValue({ status: 200, data: mockData });
+      postMangaEntriesCollectionsSpy.mockResolvedValue({ status: 200, data });
 
-      const data = await apiService.addMangaEntry(mangaURL, status);
-      expect(data).toEqual(mockData);
+      const response = await apiService.addMangaEntry(mangaURL, status);
+
+      expect(response.data).toEqual(data);
+      expect(postMangaEntriesCollectionsSpy).toHaveBeenCalledWith(
+        '/api/v1/manga_entries/',
+        { manga_entry: { series_url: mangaURL, status } },
+      );
     });
 
-    it('makes a request to the API and returns not_found status if series not found', async () => {
-      const mangaURL = 'example.url/invalidURL';
-      const mangaListID = 1;
-      axios.post.mockResolvedValue({ status: 404, data: {} });
+    it('makes a request to the resource and returns false if failed', async () => {
+      axios.post.mockRejectedValue({ status: 500 });
 
-      const data = await apiService.addMangaEntry(mangaURL, mangaListID);
-      expect(data).toEqual({});
+      const response = await apiService.addMangaEntry('', 0);
+      expect(response).toBeFalsy();
     });
   });
 

--- a/tests/services/api.spec.js
+++ b/tests/services/api.spec.js
@@ -6,7 +6,7 @@ describe('API', () => {
     jest.restoreAllMocks();
   });
 
-  describe('addMangaEntry()', () => {
+  describe('create()', () => {
     it('makes a request to the resource and returns data', async () => {
       const postMangaEntriesCollectionsSpy = jest.spyOn(axios, 'post');
       const mangaURL = 'example.url/123';
@@ -15,7 +15,7 @@ describe('API', () => {
 
       postMangaEntriesCollectionsSpy.mockResolvedValue({ status: 200, data });
 
-      const response = await apiService.addMangaEntry(mangaURL, status);
+      const response = await apiService.create(mangaURL, status);
 
       expect(response.data).toEqual(data);
       expect(postMangaEntriesCollectionsSpy).toHaveBeenCalledWith(
@@ -27,7 +27,7 @@ describe('API', () => {
     it('makes a request to the resource and returns false if failed', async () => {
       axios.post.mockRejectedValue({ status: 500 });
 
-      const response = await apiService.addMangaEntry('', 0);
+      const response = await apiService.create('', 0);
       expect(response).toBeFalsy();
     });
   });

--- a/tests/store/modules/lists.spec.js
+++ b/tests/store/modules/lists.spec.js
@@ -56,13 +56,13 @@ describe('lists', () => {
     });
 
     describe('addEntry', () => {
-      it('adds a new manga entry to state', () => {
+      it('adds a new manga entry to start of entries array', () => {
         const newEntry = factories.entry.build({ id: 2 });
         const state = { entries: factories.entry.buildList(1) };
 
         lists.mutations.addEntry(state, newEntry);
 
-        expect(state.entries).toContain(newEntry);
+        expect(state.entries[0]).toEqual(newEntry);
       });
     });
 


### PR DESCRIPTION
Due to the addition of the server-side pagination, adding new entries, wouldn't correct sort them and always add at the end of the current page. So this PR changes the logic, to always add the new entry at the _start_ of the current page, so even if it's unsorted, you see a visual indication of your entry being added.

I also finally moved to async on `addEntry` and refactor some other things. This is mostly a hotfix, I need to figure out the right way to order the new entry correctly, with the server-side pagination. Although having it at the top, always, does provide a good indicator of the new entry, while ordering it off the current page, might not be right regardless :thinking: