### PR TITLE
Add forms for inputs

### DIFF
--- a/src/components/TheResetPassword.vue
+++ b/src/components/TheResetPassword.vue
@@ -7,7 +7,7 @@
         buttonText="Close"
         @completeAction="$emit('signOnFinished')"
       )
-    template(v-else)
+    form(v-else @submit.prevent="resetPassword")
       base-form-input(
         v-model.trim="$v.user.email.$model"
         :validator="$v.user.email"
@@ -18,7 +18,7 @@
       )
         template(slot='icon')
           icon-mail.h-5.w-5
-      base-button.mt-5(ref='resetPasswordSubmit' @click='resetPassword')
+      base-button.mt-5(ref='resetPasswordSubmit' type='submit')
         | Reset Password
       .text-center
         el-divider.my-4
@@ -63,7 +63,7 @@
       async resetPassword() {
         this.$v.$touch();
         if (this.$v.$invalid) return;
-        
+
         this.$emit('loading', true);
 
         const response = await plain

--- a/src/components/TheSignIn.vue
+++ b/src/components/TheSignIn.vue
@@ -1,5 +1,5 @@
 <template lang="pug">
-  .w-full
+  form.w-full(@submit.prevent="submitForm")
     base-form-input(
       v-model.trim="$v.user.email.$model"
       :validator="$v.user.email"
@@ -14,7 +14,7 @@
       type="password"
     )
     base-form-checkbox.mt-5(v-model="user.remember_me") Remember Me (2 months)
-    base-button.mt-5(ref='signInSubmit' @click='submitForm') Sign In
+    base-button.mt-5(ref='signInSubmit' type="submit") Sign In
     .text-center
       el-link.mt-4(
         @click.native="$emit('componentChanged', 'TheResetPassword')"

--- a/src/components/TheSignUp.vue
+++ b/src/components/TheSignUp.vue
@@ -7,7 +7,7 @@
         buttonText="Close"
         @completeAction="$emit('signOnFinished')"
       )
-    template(v-else)
+    form(v-else @submit.prevent="signUp")
       base-form-input(
         v-model.trim="$v.user.email.$model"
         :validator="$v.user.email"
@@ -28,7 +28,7 @@
         placeholder="Password confirmation"
         type="password"
       )
-      base-button.mt-5(ref='signUpSubmit' @click='signUp') Register
+      base-button.mt-5(ref='signUpSubmit' type='submit') Register
       .text-center
         el-divider.my-4
         span.text-sm

--- a/src/components/base_components/BaseButton.vue
+++ b/src/components/base_components/BaseButton.vue
@@ -1,6 +1,6 @@
 <template lang="pug">
   button(
-    type='button'
+    :type='type'
     :class='classes'
     :disabled='disabled'
     @click="$emit('click')"
@@ -12,6 +12,10 @@
   export default {
     props: {
       type: {
+        type: String,
+        default: 'button',
+      },
+      colour: {
         type: String,
         default: 'primary',
       },
@@ -27,12 +31,12 @@
     computed: {
       classes() {
         return {
-          'btn-primary': this.type === 'primary',
-          'btn-success': this.type === 'success',
-          'btn-secondary': this.type === 'secondary',
-          'btn-info': this.type === 'info',
-          'btn-warn': this.type === 'warning',
-          'btn-danger': this.type === 'danger',
+          'btn-primary': this.colour === 'primary',
+          'btn-success': this.colour === 'success',
+          'btn-secondary': this.colour === 'secondary',
+          'btn-info': this.colour === 'info',
+          'btn-warn': this.colour === 'warning',
+          'btn-danger': this.colour === 'danger',
           'btn-xl': this.size === 'xl',
           'btn-lg': this.size === 'lg',
           'btn-md': this.size === 'md',

--- a/src/components/base_components/BaseNavDark.vue
+++ b/src/components/base_components/BaseNavDark.vue
@@ -33,7 +33,7 @@
           template(v-if="!signedIn")
             base-button(
               ref="signInButton"
-              type="secondary"
+              colour="secondary"
               @click="openSignOnWith('TheSignIn')"
             ) Sign In
             base-button.ml-3(

--- a/src/components/base_components/BaseNavLight.vue
+++ b/src/components/base_components/BaseNavLight.vue
@@ -32,7 +32,7 @@
           template(v-if="!signedIn")
             base-button(
               ref="signInButton"
-              type="secondary"
+              colour="secondary"
               @click="openSignOnWith('TheSignIn')"
             ) Sign In
             base-button.ml-3(

--- a/src/components/manga_entries/AddMangaEntry.vue
+++ b/src/components/manga_entries/AddMangaEntry.vue
@@ -32,7 +32,7 @@
         base-button(ref="addMangaButton" @click="addMangaEntry")
           | Add
       span.mt-3.flex.w-full.rounded-md.shadow-sm.sm_mt-0.sm_w-auto
-        base-button(type="secondary" @click="closeModal()") Cancel
+        base-button(colour="secondary" @click="closeModal()") Cancel
 </template>
 
 <script>

--- a/src/components/manga_entries/DeleteMangaEntries.vue
+++ b/src/components/manga_entries/DeleteMangaEntries.vue
@@ -13,10 +13,10 @@
             | use the edit button to switch to a different source.
     template(slot='actions')
       span.flex.w-full.rounded-md.shadow-sm.sm_ml-3.sm_w-auto
-        base-button(type="danger" @click="$emit('confirmDeletion')")
+        base-button(colour="danger" @click="$emit('confirmDeletion')")
           | Delete
       span.mt-3.flex.w-full.rounded-md.shadow-sm.sm_mt-0.sm_w-auto
-        base-button(type="secondary" @click="$emit('dialogClosed')")
+        base-button(colour="secondary" @click="$emit('dialogClosed')")
           | Cancel
 </template>
 

--- a/src/components/manga_entries/EditMangaEntries.vue
+++ b/src/components/manga_entries/EditMangaEntries.vue
@@ -60,7 +60,7 @@
         )
           | Update
       span.mt-3.sm_mt-0.flex.w-full.rounded-md.shadow-sm.sm_w-auto
-        base-button(type="secondary" @click="$emit('editComplete')") Cancel
+        base-button(colour="secondary" @click="$emit('editComplete')") Cancel
 </template>
 
 <script>

--- a/src/components/manga_entries/ReportMangaEntries.vue
+++ b/src/components/manga_entries/ReportMangaEntries.vue
@@ -29,13 +29,13 @@
       span.sm_ml-3.flex.w-full.rounded-md.shadow-sm.sm_w-auto
         base-button(
           ref="reportEntriesButton"
-          type="danger"
+          colour="danger"
           @click="report"
           :disabled="issueInvalid"
         )
           | Report
       span.mt-3.sm_mt-0.flex.w-full.rounded-md.shadow-sm.sm_w-auto
-        base-button(type="secondary" @click="$emit('closeDialog')") Cancel
+        base-button(colour="secondary" @click="$emit('closeDialog')") Cancel
 </template>
 
 <script>

--- a/src/components/settings/SettingsAccountTerminationSection.vue
+++ b/src/components/settings/SettingsAccountTerminationSection.vue
@@ -8,7 +8,7 @@
             | Deleting your account is irreversable, so make sure you have
             | exported all data, before proceeding
       .mt-5.md_mt-0.md_col-span-1.self-center
-        base-button(type='danger' @click="confirmationVisible = true")
+        base-button(colour='danger' @click="confirmationVisible = true")
           | Delete Account
       base-modal(
         :visible="confirmationVisible"
@@ -28,10 +28,10 @@
                 | manga entries and tags. Do you want to proceed?
         template(slot='actions')
           span.flex.w-full.rounded-md.shadow-sm.sm_ml-3.sm_w-auto
-            base-button(type="danger" @click="deleteAccount")
+            base-button(colour="danger" @click="deleteAccount")
               | Confirm
           span.mt-3.flex.w-full.rounded-md.shadow-sm.sm_mt-0.sm_w-auto
-            base-button(type="secondary" @click="confirmationVisible = false")
+            base-button(colour="secondary" @click="confirmationVisible = false")
               | Cancel
 </template>
 

--- a/src/components/settings/SettingsMangaListTags.vue
+++ b/src/components/settings/SettingsMangaListTags.vue
@@ -42,12 +42,12 @@
           | Total {{ tags.length }} tags
       .flex.flex-initial.justify-between.sm_justify-end
         base-button(
-          type="secondary"
+          colour="secondary"
           :disabled="currentPage - 1 === 0"
           @click="currentPage -= 1"
         ) Previous
         base-button.ml-3(
-          type="secondary"
+          colour="secondary"
           :disabled="currentPage + 1 > pages"
           @click="currentPage += 1"
         ) Next
@@ -87,7 +87,7 @@
           base-button(ref="addTagButton" @click="upsertTag")
             | Add
         span.mt-3.flex.w-full.rounded-md.shadow-sm.sm_mt-0.sm_w-auto
-          base-button(type="secondary" @click="closeModal()") Cancel
+          base-button(colour="secondary" @click="closeModal()") Cancel
 </template>
 
 <script>

--- a/src/views/MangaList.vue
+++ b/src/views/MangaList.vue
@@ -65,7 +65,7 @@
               i.el-icon-plus.mr-1
               | Add Manga
           span.flex.mt-3.sm_mt-0.w-full.rounded-md.shadow-sm.sm_w-auto
-            base-button(type="success" @click="importDialogVisible = true")
+            base-button(colour="success" @click="importDialogVisible = true")
               i.el-icon-upload2.mr-1
               | Import
       .flex-grow.sm_mx-5.mx-0

--- a/src/views/ResetPassword.vue
+++ b/src/views/ResetPassword.vue
@@ -8,7 +8,7 @@
           | Checking token validity
           br
           i.el-icon-loading
-        template(v-else-if="tokenValid")
+        form(v-else-if="tokenValid" @submit.prevent="submitNewPassword")
           h3.leading-normal.text-gray-600.text-center
             | Reset Password
           base-form-input.mt-5(
@@ -25,7 +25,7 @@
             autocomplete='new-password'
             type="password"
           )
-          base-button.mt-5(ref='resetPasswordSubmit' @click='submitNewPassword')
+          base-button.mt-5(ref='resetPasswordSubmit' type='submit')
             | Save Password
         p.leading-normal.text-gray-600.text-center(v-else)
           | {{ this.validationError }}

--- a/tests/components/TheResetPassword.spec.js
+++ b/tests/components/TheResetPassword.spec.js
@@ -41,9 +41,10 @@ describe('TheResetPassword.vue', () => {
 
     describe('and has client-side errors', () => {
       it('shows client-side errors', async () => {
-        await resetPassword
-          .findComponent({ ref: 'resetPasswordSubmit' })
-          .trigger('click');
+        await resetPassword.find('form').trigger('submit.prevent');
+        // await resetPassword
+        //   .findComponent({ ref: 'resetPasswordSubmit' })
+        //   .trigger('click');
 
         expect(resetPassword.text()).toContain('Emailrequired');
       });

--- a/tests/components/TheSignIn.spec.js
+++ b/tests/components/TheSignIn.spec.js
@@ -72,15 +72,16 @@ describe('TheSignIn.vue', () => {
           data() { return { user: userData }; },
         });
 
-        signIn.findComponent({ ref: 'signInSubmit' }).trigger('click');
+        await signIn.find('form').trigger('submit.prevent');
 
-        expect(actions.signIn).toHaveBeenCalledWith(expect.anything(), userData);
+        expect(actions.signIn)
+          .toHaveBeenCalledWith(expect.anything(), userData);
       });
     });
 
     describe('when form is invalid', () => {
       it('shows validation errors', async () => {
-        await signIn.findComponent({ ref: 'signInSubmit' }).trigger('click');
+        await signIn.find('form').trigger('submit.prevent');
 
         expect(signIn.text()).toContain('required');
       });

--- a/tests/components/TheSignUp.spec.js
+++ b/tests/components/TheSignUp.spec.js
@@ -72,7 +72,7 @@ describe('TheSignUp.vue', () => {
 
     describe(':user - is invalid', () => {
       it('shows validation errors if form is invalid', async () => {
-        await signUp.findComponent({ ref: 'signUpSubmit' }).trigger('click');
+        await signUp.find('form').trigger('submit.prevent');
 
         expect(signUp.text()).toContain('Emailrequired');
       });

--- a/tests/views/ResetPassword.spec.js
+++ b/tests/views/ResetPassword.spec.js
@@ -167,9 +167,7 @@ describe('ResetPassword.vue', () => {
           },
         });
 
-        await resetPassword
-          .findComponent({ ref: 'resetPasswordSubmit' })
-          .trigger('click');
+        await resetPassword.find('form').trigger('submit.prevent');
 
         expect(resetPassword.text()).toContain('must be identical');
       });
@@ -189,10 +187,7 @@ describe('ResetPassword.vue', () => {
 
         resetPasswordSpy.mockResolvedValue({ status: 200, data: user });
 
-        resetPassword
-          .findComponent({ ref: 'resetPasswordSubmit' })
-          .trigger('click');
-
+        await resetPassword.find('form').trigger('submit.prevent');
         await flushPromises();
 
         expect(router.currentRoute.name).toBe('manga-list');
@@ -218,8 +213,7 @@ describe('ResetPassword.vue', () => {
           { status: 500, data: { error: 'Wrong user' } },
         );
 
-        resetPassword.findComponent({ ref: 'resetPasswordSubmit' }).trigger('click');
-
+        await resetPassword.find('form').trigger('submit.prevent');
         await flushPromises();
 
         expect(errorMessageSpy).toBeCalledWith(


### PR DESCRIPTION
This is the final change needed to finish #405, as it adds forms to go with the base form inputs, so that users can press Enter, to easilly submit their data in Sign In, Sign Up and so on. They are missing from all the inputs, especially in modals, as they end up being in different slots, which is something I need to figure out how to fix. But they are present in most important places