### PR TITLE
Reset validations on modal closure

### DIFF
--- a/src/components/TheImporters.vue
+++ b/src/components/TheImporters.vue
@@ -101,6 +101,7 @@
         if (!newVal) {
           // Reset data to initial state
           Object.assign(this.$data, this.$options.data.call(this));
+          this.$v.$reset();
         }
       }, 250),
     },

--- a/src/components/manga_entries/AddMangaEntry.vue
+++ b/src/components/manga_entries/AddMangaEntry.vue
@@ -125,6 +125,7 @@
         this.$emit('dialogClosed');
         this.loading = false;
         this.mangaURL = '';
+        this.$v.$reset();
       },
     },
   };


### PR DESCRIPTION
I kept on showing if the validations failed, when you closed Importers or AddMangaEntry modals. Especially in the latter case, after you submitted the actual manga url, because we reset it back to empty string, the validation would fire again, which was not desirable at all

![image](https://user-images.githubusercontent.com/4270980/95180425-df33f300-07b9-11eb-954d-a9b075a7a9e5.png)
