### PR TITLE
Add ability to add manga by search

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -21,7 +21,7 @@ module.exports = {
   ],
   rules: {
     'no-nested-ternary': 'off',
-    'no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
+    'no-unused-vars': ['error', { argsIgnorePattern: '^_', ignoreRestSiblings: true }],
     'comma-dangle': ['error', 'always-multiline'],
     'no-shadow': 'off',
     'no-param-reassign': 'off',

--- a/package.json
+++ b/package.json
@@ -20,6 +20,8 @@
     "element-ui": "^2.12.0",
     "he": "^1.2.0",
     "lodash": "^4.17.20",
+    "overlayscrollbars": "^1.13.0",
+    "overlayscrollbars-vue": "^0.2.2",
     "pug-plain-loader": "^1.0.0",
     "qs": "^6.9.3",
     "vue": "^2.6.11",
@@ -36,8 +38,8 @@
     "vuex-persist": "^2.2.0"
   },
   "devDependencies": {
-    "@testing-library/jest-dom": "^5.11.3",
     "@kazupon/vue-i18n-loader": "^0.3.0",
+    "@testing-library/jest-dom": "^5.11.3",
     "@vue/cli-plugin-babel": "~4.5.3",
     "@vue/cli-plugin-eslint": "~4.5.3",
     "@vue/cli-plugin-unit-jest": "~4.5.3",

--- a/src/components/base_components/BaseFormAutocomplete.vue
+++ b/src/components/base_components/BaseFormAutocomplete.vue
@@ -1,0 +1,192 @@
+<template lang="pug">
+  .relative
+    template(v-if="selectedValue")
+      label.mb-1(v-if="label" v-text="label")
+      .flex.shadow-sm.rounded-md
+        a.form-input.w-full(href='#' @click.prevent="resetSelection")
+          .text-sm.leading-5.relative
+            .icon.text-gray-400(v-if="$slots.icon")
+              slot(name="icon")
+            p.selected-value(v-text="selectedValue")
+      p.mt-2.text-xs.text-gray-500(v-if="helperText" v-text="helperText")
+    base-form-input(
+      v-else
+      ref="searchInput"
+      :value="value"
+      :label="label"
+      :placeholder="placeholder"
+      :helperText="helperText"
+      :validator="validator"
+      @input="debounceInput($event)"
+      @focus="onFocus"
+    )
+      template(slot='icon')
+        slot(name="icon")
+    button.fixed.inset-0.h-full.w-full.cursor-default.focus_outline-none(
+      ref="clickOffButton"
+      v-show='dropdownOpen'
+      @click='dropdownOpen = false'
+      tabindex='-1'
+    )
+    transition(name="dropdown")
+      .dropdown-body(v-show='dropdownOpen')
+        overlay-scrollbars.max-h-56.rounded-md.bg-white.shadow-xs
+          .py-1
+            .animate-pulse.flex.space-x-4.w-full(
+              v-show="loading"
+              v-for="index in 4"
+              :key="`skeleton-${index}`"
+            )
+              .flex-1.space-y-4.py-1.px-4.py-2
+                .h-3.bg-gray-400.rounded
+            a.dropdown-item.group(
+              v-show="!loading && items.length"
+              v-for="(item, index) in items"
+              v-text="item"
+              :key="index"
+              href='#'
+              @click.stop="selectSeries(item)"
+            )
+            p.not-found(v-show="!loading && !items.length")
+              | Nothing found
+</template>
+
+<script>
+  import debounce from 'lodash/debounce';
+  import { OverlayScrollbarsComponent } from 'overlayscrollbars-vue';
+
+  export default {
+    components: {
+      'overlay-scrollbars': OverlayScrollbarsComponent,
+    },
+    props: {
+      value: {
+        type: String,
+        required: true,
+      },
+      selectedValue: {
+        type: String,
+        required: true,
+      },
+      items: {
+        type: Array,
+        default: () => [],
+      },
+      label: {
+        type: String,
+        default: null,
+      },
+      helperText: {
+        type: String,
+        default: null,
+      },
+      placeholder: {
+        type: String,
+        default: null,
+      },
+      validator: {
+        type: Object,
+        default: null,
+      },
+      loading: {
+        type: Boolean,
+        default: false,
+      },
+    },
+    data() {
+      return {
+        dropdownOpen: false,
+      };
+    },
+    watch: {
+      value(newValue) {
+        if (newValue.length) {
+          if (!this.selectedValue) { this.dropdownOpen = true; }
+        } else {
+          this.dropdownOpen = false;
+        }
+      },
+    },
+    methods: {
+      debounceInput: debounce(function (input) { //eslint-disable-line
+        this.$emit('input', input);
+      }, 350),
+      async resetSelection() {
+        this.$emit('selected', '');
+        this.dropdownOpen = true;
+
+        await this.$nextTick();
+
+        this.$refs.searchInput.focus();
+      },
+      async selectSeries(item) {
+        this.$emit('selected', item);
+        this.dropdownOpen = false;
+      },
+      onFocus() {
+        if (this.value.length) { this.dropdownOpen = true; }
+      },
+    },
+  };
+</script>
+
+<style lang="scss" scoped>
+  label {
+    @apply block text-sm font-medium leading-5 text-gray-700;
+  }
+
+  .not-found {
+    @apply flex items-center px-4 py-2 text-sm leading-5 text-gray-700;
+  }
+
+  .icon {
+    @apply absolute inset-y-0 flex items-center pointer-events-none;
+
+    left: -1px;
+  }
+
+  .selected-value {
+    @apply text-gray-900 font-medium truncate pl-7 text-base leading-6;
+
+    @screen sm {
+      @apply text-sm leading-5;
+    }
+  }
+
+  .dropdown-body {
+    @apply origin-top-right absolute right-0 -mt-4 rounded-md shadow-lg w-full;
+    @apply z-50;
+  }
+
+  .dropdown-item {
+    @apply flex items-center px-4 py-2 text-sm leading-5 text-gray-700;
+
+    &:hover {
+      @apply bg-gray-100 text-gray-900;
+    }
+
+    &:focus {
+      @apply outline-none bg-gray-100 text-gray-900;
+    }
+  }
+
+  // Dropdown transition
+
+  .dropdown-enter-active {
+    @apply ease-out duration-100;
+  }
+
+  .dropdown-leave-active {
+    @apply ease-in duration-75;
+  }
+
+  .dropdown-enter,
+  .dropdown-leave-to {
+    @apply transform opacity-0 scale-95;
+  }
+
+  .dropdown-enter-to,
+  .dropdown-leave {
+    @apply transform opacity-100 scale-100;
+  }
+</style>

--- a/src/components/base_components/BaseFormInput.vue
+++ b/src/components/base_components/BaseFormInput.vue
@@ -2,12 +2,7 @@
   .w-full
     label.block.text-sm.font-medium.leading-5.text-gray-700(v-if="label")
       | {{ label }}
-      transition(
-        enter-active-class='slide-transition'
-        enter-class='opacity-0 transform -translate-y-1'
-        leave-active-class='slide-transition'
-        leave-to-class='opacity-0 transform -translate-y-1'
-      )
+      transition(name="slide")
         span.leading-none.ml-1.text-xs.text-red-600(
           v-if="hasErrors"
           v-t.preserve="activeError"
@@ -19,8 +14,11 @@
       )
         slot(name="icon")
       input.form-input.block.w-full.sm_text-sm.sm_leading-5(
-        v-bind:value="value"
-        v-on:input="$emit('input', $event.target.value)"
+        ref="input"
+        :value="value"
+        @input="$emit('input', $event.target.value)"
+        @focus="$emit('focus')"
+        @blur="$emit('blur')"
         :class="classes"
         :placeholder="placeholder"
         :type="type"
@@ -79,12 +77,23 @@
         };
       },
     },
+    methods: {
+      focus() {
+        this.$refs.input.focus();
+      },
+    },
   };
 </script>
 
 <style media="screen" lang="scss" scoped>
-  .slide-transition {
+  .slide-enter-active,
+  .slide-leave-active {
     @apply transition ease-in duration-200 transition-all overflow-hidden;
+  }
+
+  .slide-enter,
+  .slide-leave-to {
+    @apply opacity-0 transform -translate-y-1;
   }
 
   .icon {

--- a/src/components/base_components/BaseTabs.vue
+++ b/src/components/base_components/BaseTabs.vue
@@ -1,0 +1,52 @@
+<template lang="pug">
+  .border-b.border-gray-200
+    nav.-mb-px.flex
+      a(
+        href='#'
+        v-for="tab in tabs"
+        v-text="tab"
+        :class="classes(tab)"
+        @click.prevent="$emit('tabSelected', tab)"
+      )
+</template>
+
+<script>
+  export default {
+    props: {
+      tabs: {
+        type: Array,
+        required: true,
+      },
+      selectedTab: {
+        type: String,
+        default: '',
+      },
+    },
+    methods: {
+      classes(tab) {
+        return {
+          'active-tab': tab === this.selectedTab,
+          tab: tab !== this.selectedTab,
+        };
+      },
+    },
+  };
+</script>
+
+<style lang="scss" scoped>
+  a {
+    @apply py-3 px-1 text-center border-b-2 font-medium text-sm leading-5 w-2/4;
+  }
+
+  .tab {
+    @apply border-transparent text-gray-500;
+
+    &:hover {
+      @apply text-gray-700 border-gray-300;
+    }
+  }
+
+  .active-tab {
+    @apply border-blue-500 text-blue-600;
+  }
+</style>

--- a/src/components/manga_entries/AddMangaEntryBySearch.vue
+++ b/src/components/manga_entries/AddMangaEntryBySearch.vue
@@ -1,0 +1,146 @@
+<template lang="pug">
+  .relative
+    base-form-autocomplete(
+      label="Series title"
+      placeholder="One Piece"
+      helperText="You can search by English or Romaji titles"
+      :value="searchQuery"
+      :selectedValue="selectedSeriesTitle"
+      :items="seriesTitles"
+      :loading="loading"
+      :validator="validator.searchQuery"
+      @selected="$emit('seriesSelected', $event)"
+      @input="$emit('input', $event)"
+    )
+      template(slot='icon')
+        icon-search.h-5.w-5
+    .mt-5.text-left.w-full.sm_block(:class="responsiveClasses")
+      label.block.text-sm.font-medium.leading-5.text-gray-700
+        | Source Name
+        transition(name='slide')
+          span.leading-none.ml-1.text-xs.text-red-600(v-if="hasErrors")
+            | required
+      .mt-1.relative.rounded-md.shadow-sm.w-auto
+        el-select.rounded.w-full(
+          placeholder="Select series first"
+          :value="mangaSourceID"
+          :disabled="!availableSources.length"
+          @change="$emit('mangaSourceSelected', $event)"
+        )
+          el-option(
+            v-for="source in availableSources"
+            :key="source.id"
+            :label="source.name"
+            :value="source.id"
+          )
+</template>
+
+<script>
+  import he from 'he';
+  import { Message, Select, Option } from 'element-ui';
+  import { mapState } from 'vuex';
+
+  import { index } from '@/services/endpoints/v1/manga_series';
+
+  export default {
+    components: {
+      'el-select': Select,
+      'el-option': Option,
+    },
+    props: {
+      searchQuery: {
+        type: String,
+        required: true,
+      },
+      mangaSourceID: {
+        type: Number,
+        default: null,
+      },
+      selectedSeriesTitle: {
+        type: String,
+        default: '',
+      },
+      validator: {
+        type: Object,
+        required: true,
+      },
+    },
+    data() {
+      return {
+        loading: false,
+        items: [],
+      };
+    },
+    computed: {
+      ...mapState('lists', [
+        'statuses',
+      ]),
+      responsiveClasses() {
+        return {
+          hidden: !this.availableSources.length,
+        };
+      },
+      hasErrors() {
+        const { mangaSourceID } = this.validator;
+
+        return !mangaSourceID.required
+          && mangaSourceID.$dirty
+          && this.availableSources.length;
+      },
+      seriesTitles() {
+        return this.items.map((item) => he.decode(item.title));
+      },
+      selectedSeries() {
+        return this.items
+          .find((item) => item.title === this.selectedSeriesTitle);
+      },
+      availableSources() {
+        if (!this.selectedSeries) { return []; }
+
+        return this.selectedSeries.mangaSources;
+      },
+    },
+    watch: {
+      async searchQuery(title) {
+        if (!title.length) {
+          this.items = [];
+          return;
+        }
+
+        this.loading = true;
+
+        const response = await index(title);
+        const { status, data } = response;
+
+        if (status === 200) {
+          this.items = data.data;
+        } else {
+          Message.error(
+            "Couldn't fetch series. Try refreshing the page before trying again",
+          );
+        }
+
+        this.loading = false;
+      },
+      availableSources(sources) {
+        if (!sources.length) return;
+
+        this.$emit('mangaSourceSelected', sources[0].id);
+      },
+    },
+    methods: {
+    },
+  };
+</script>
+
+<style lang="scss" scoped>
+  .slide-enter-active,
+  .slide-leave-active {
+    @apply transition ease-in duration-200 transition-all overflow-hidden;
+  }
+
+  .slide-enter,
+  .slide-leave-to {
+    @apply opacity-0 transform -translate-y-1;
+  }
+</style>

--- a/src/packs/main.js
+++ b/src/packs/main.js
@@ -13,6 +13,7 @@ import '@/stylesheets/tailwind.css';
 import '@/stylesheets/global.scss';
 import '@/stylesheets/transitions.scss';
 import 'tippy.js/themes/light.css';
+import 'overlayscrollbars/css/OverlayScrollbars.css';
 
 import router from '@/router/';
 import store from '@/store/index';

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -1,8 +1,8 @@
 import { secure } from '@/modules/axios';
 
-export const create = (seriesURL, status) => secure
+export const create = (seriesURL, status, sourceID) => secure
   .post('/api/v1/manga_entries/', {
-    manga_entry: { series_url: seriesURL, status },
+    manga_entry: { series_url: seriesURL, status, manga_source_id: sourceID },
   })
   .then((response) => response)
   .catch((request) => request.response);

--- a/src/services/endpoints/v1/manga_series.js
+++ b/src/services/endpoints/v1/manga_series.js
@@ -1,0 +1,10 @@
+import { secure } from '@/modules/axios';
+
+const baseURL = '/api/v1/manga_series';
+
+/* eslint-disable import/prefer-default-export, object-curly-newline */
+export const index = (searchTerm) => secure
+  .get(baseURL, { params: { search_term: searchTerm } })
+  .then((response) => response)
+  .catch((request) => request.response);
+/* eslint-enable import/prefer-default-export */

--- a/tests/components/base_components/BaseFormAutocomplete.spec.js
+++ b/tests/components/base_components/BaseFormAutocomplete.spec.js
@@ -1,0 +1,109 @@
+import BaseFormAutocomplete from '@/components/base_components/BaseFormAutocomplete.vue';
+
+describe('BaseFormAutocomplete.vue', () => {
+  let baseFormAutocomplete;
+
+  beforeEach(() => {
+    baseFormAutocomplete = shallowMount(BaseFormAutocomplete, {
+      propsData: { value: '', selectedValue: '' },
+    });
+  });
+
+  describe('when selectedValue is provided', () => {
+    beforeEach(() => {
+      baseFormAutocomplete.setProps({ value: '', selectedValue: 'Some value' });
+    });
+
+    it('shows selected value', async () => {
+      expect(baseFormAutocomplete.text()).toContain('Some value');
+    });
+
+    describe("and it's being pressed", () => {
+      beforeEach(() => {
+        baseFormAutocomplete.setProps({
+          value: '', selectedValue: 'Some value',
+        });
+      });
+
+      // TODO: Figure out how to simulate Parent Component sending back
+      // updated selectedValue, so that the base input shows up and receives
+      // focus
+      it.skip('resets the selection', async () => {
+        const selectedValue = baseFormAutocomplete.find('a');
+        const dropdown      = baseFormAutocomplete.find('.dropdown-body');
+
+        await selectedValue.trigger('click');
+
+        expect(dropdown.element).toBeVisible();
+        expect(baseFormAutocomplete.emitted('selected')[0]).toEqual(['']);
+      });
+    });
+  });
+
+  describe('when value is provided', () => {
+    describe('and it is not blank', () => {
+      beforeEach(() => {
+        baseFormAutocomplete.setProps({ value: 'some value' });
+      });
+
+      describe('with loading true', () => {
+        beforeEach(() => {
+          baseFormAutocomplete.setProps({ loading: true });
+        });
+
+        it('shows skeleton loading', async () => {
+          const skeleton = baseFormAutocomplete.findAll('.animate-pulse');
+          expect(skeleton.at(0).element).toBeVisible();
+        });
+      });
+
+      describe('with loading false', () => {
+        beforeEach(() => {
+          baseFormAutocomplete.setProps({ loading: false });
+        });
+
+        describe('and items are not blank', () => {
+          beforeEach(() => {
+            baseFormAutocomplete.setProps({ items: ['Title 1', 'Title 2'] });
+          });
+
+          it('shows dropdown with items', async () => {
+            const dropdownListItem = baseFormAutocomplete.findAll('a').at(0);
+            expect(dropdownListItem.element).toBeVisible();
+            expect(dropdownListItem.text()).toContain('Title 1');
+          });
+
+          describe('and link is clicked', () => {
+            it('emits selected value and closes dropdown', async () => {
+              const dropdownListItem = baseFormAutocomplete.findAll('a').at(0);
+              const dropdown = baseFormAutocomplete.find('.dropdown-body');
+
+              await dropdownListItem.trigger('click');
+
+              expect(dropdown.element).not.toBeVisible();
+              expect(baseFormAutocomplete.emitted('selected')[0])
+                .toEqual(['Title 1']);
+            });
+          });
+        });
+
+        describe('and items are blank', () => {
+          it('shows Nothing found', async () => {
+            const nothingFound = baseFormAutocomplete.find('p');
+
+            expect(baseFormAutocomplete.findAll('a').exists()).toBeFalsy();
+            expect(nothingFound.element).toBeVisible();
+            expect(nothingFound.text()).toContain('Nothing found');
+          });
+        });
+      });
+    });
+
+    describe('and it is blank', () => {
+      it("doesn't show the dropdown", async () => {
+        const dropdown = baseFormAutocomplete.find('.dropdown-body');
+        expect(dropdown.element).not.toBeVisible();
+      });
+    });
+  });
+});

--- a/tests/components/base_components/BaseFormInput.spec.js
+++ b/tests/components/base_components/BaseFormInput.spec.js
@@ -8,6 +8,14 @@ describe('BaseDropdown.vue', () => {
     baseFormInput = mount(BaseFormInput, { i18n, propsData: { value: '' } });
   });
 
+  describe('when calling focus method', () => {
+    it('focuses input', () => {
+      baseFormInput.vm.focus();
+
+      expect(baseFormInput.find('input').element).toHaveFocus();
+    });
+  });
+
   describe('when input is detected', () => {
     it('emits input value', async () => {
       await baseFormInput.find('input').setValue('new value');

--- a/tests/components/base_components/BaseTabs.spec.js
+++ b/tests/components/base_components/BaseTabs.spec.js
@@ -1,0 +1,19 @@
+import BaseTabs from '@/components/base_components/BaseTabs.vue';
+
+describe('BaseTabs.vue', () => {
+  let baseTabs;
+
+  beforeEach(() => {
+    baseTabs = shallowMount(BaseTabs, {
+      propsData: { tabs: ['Tab 1', 'Tab 2'] },
+    });
+  });
+
+  describe('when selecting a tab', () => {
+    it('emits text of the tab select', async () => {
+      await baseTabs.findAll('a').at(1).trigger('click');
+
+      expect(baseTabs.emitted('tabSelected')[0]).toEqual(['Tab 2']);
+    });
+  });
+});

--- a/tests/components/manga_entries/AddMangaEntry.spec.js
+++ b/tests/components/manga_entries/AddMangaEntry.spec.js
@@ -3,12 +3,15 @@ import Vuex from 'vuex';
 import { Message } from 'element-ui';
 import flushPromises from 'flush-promises';
 import AddMangaEntry from '@/components/manga_entries/AddMangaEntry.vue';
+import AddMangaEntryBySearch from '@/components/manga_entries/AddMangaEntryBySearch.vue';
 import lists from '@/store/modules/lists';
 import * as api from '@/services/api';
 
 const localVue = createLocalVue();
 
 localVue.use(Vuex);
+
+jest.useFakeTimers();
 
 describe('AddMangaEntry.vue', () => {
   let store;
@@ -26,7 +29,228 @@ describe('AddMangaEntry.vue', () => {
       },
     });
 
-    addMangaEntry = shallowMount(AddMangaEntry, { store, localVue, i18n });
+    addMangaEntry = shallowMount(AddMangaEntry, {
+      store,
+      localVue,
+      i18n,
+      propsData: { visible: true },
+    });
+  });
+
+  describe('when tabs are switched', () => {
+    it('resets data to original state', async () => {
+      await addMangaEntry
+        .setData({ searchQuery: 'query', selectedSeriesTitle: 'Title' });
+
+      expect(addMangaEntry.vm.searchQuery).toEqual('query');
+      expect(addMangaEntry.vm.selectedSeriesTitle).toEqual('Title');
+
+      await addMangaEntry.setData({ selectedTab: 'Add with URL' });
+
+      expect(addMangaEntry.vm.searchQuery).toEqual('');
+      expect(addMangaEntry.vm.selectedSeriesTitle).toEqual('');
+    });
+  });
+
+  describe('when modal is closed', () => {
+    it.skip('resets data to original state', async () => {
+      await addMangaEntry.setData({
+        searchQuery: 'query', selectedSeriesTitle: 'Title',
+      });
+
+      expect(addMangaEntry.vm.searchQuery).toEqual('query');
+      expect(addMangaEntry.vm.selectedSeriesTitle).toEqual('Title');
+
+      await addMangaEntry.setProps({ visible: false });
+      jest.runAllTimers();
+
+      expect(addMangaEntry.vm.searchQuery).toEqual('');
+      expect(addMangaEntry.vm.selectedSeriesTitle).toEqual('');
+    });
+  });
+
+  describe('when search tab is selected', () => {
+    beforeEach(() => {
+      addMangaEntry.setData({ selectedTab: 'Search' });
+    });
+
+    describe('and series title is selected', () => {
+      beforeEach(() => {
+        addMangaEntry
+          .findComponent(AddMangaEntryBySearch)
+          .vm
+          .$emit('seriesSelected', 'Title');
+      });
+
+      it('sets selectedSeriesTitle and resets mangaSourceID', async () => {
+        expect(addMangaEntry.vm.selectedSeriesTitle).toEqual('Title');
+        expect(addMangaEntry.vm.mangaSourceID).toEqual(null);
+      });
+    });
+
+    describe('and manga source is selected', () => {
+      beforeEach(() => {
+        addMangaEntry
+          .findComponent(AddMangaEntryBySearch)
+          .vm
+          .$emit('mangaSourceSelected', 123);
+      });
+
+      it('sets mangaSourceID', async () => {
+        expect(addMangaEntry.vm.mangaSourceID).toEqual(123);
+      });
+    });
+
+    describe('and new manga entry is being added', () => {
+      let createEntrySpy;
+
+      beforeEach(() => {
+        addMangaEntry.setData({
+          searchQuery: 'query',
+          selectedSeriesTitle: 'title',
+          mangaSourceID: 123,
+        });
+
+        createEntrySpy = jest.spyOn(api, 'create');
+      });
+
+
+      it('calls create endpoint with mangaSourceID', async () => {
+        addMangaEntry.vm.addMangaEntry();
+
+        await flushPromises();
+
+        expect(createEntrySpy).toHaveBeenCalledWith('', 1, 123);
+      });
+    });
+
+    describe('and there are client-side errors', () => {
+      it.todo('shows validation errors');
+    });
+  });
+
+  describe('when add by url tab is selected', () => {
+    beforeEach(() => {
+      addMangaEntry.setData({ selectedTab: 'Add with URL' });
+    });
+
+    describe('and new manga entry is being added', () => {
+      let createEntrySpy;
+
+      beforeEach(() => {
+        addMangaEntry.setData({ mangaURL: 'http://www.example.url/manga/1' });
+
+        createEntrySpy = jest.spyOn(api, 'create');
+      });
+
+      afterEach(() => {
+        expect(createEntrySpy)
+          .toHaveBeenCalledWith('http://www.example.url/manga/1', 1);
+      });
+
+      describe('when no manga sources are tracked', () => {
+        it('adds new Manga entry', async () => {
+          const mangaEntry = factories.entry.build();
+
+          createEntrySpy.mockResolvedValue({
+            status: 200, data: { data: mangaEntry },
+          });
+
+          addMangaEntry.vm.addMangaEntry();
+
+          await flushPromises();
+
+          expect(store.state.lists.entries).toContain(mangaEntry);
+          expect(addMangaEntry.emitted('dialogClosed')).toBeTruthy();
+        });
+      });
+
+      describe('when other manga source is tracked', () => {
+        it('replaces currently tracked manga entry with the new one', async () => {
+          const oldEntry = factories.entry.build();
+          store.state.lists.entries = [oldEntry];
+
+          const newMangaEntry = factories.entry.build({
+            id: 2,
+            manga_source_id: 2,
+            manga_series_id: oldEntry.manga_series_id,
+            attributes: {
+              tracked_entries: [
+                {
+                  id: oldEntry.id,
+                  manga_source_id: oldEntry.manga_source_id,
+                  manga_series_id: oldEntry.manga_series_id,
+                },
+                {
+                  id: 2,
+                  manga_source_id: 2,
+                  manga_series_id: oldEntry.manga_series_id,
+                },
+              ],
+            },
+          });
+
+          createEntrySpy.mockResolvedValue({
+            status: 200, data: { data: newMangaEntry },
+          });
+
+          addMangaEntry.vm.addMangaEntry();
+
+          await flushPromises();
+
+          expect(store.state.lists.entries).not.toContain(oldEntry);
+          expect(store.state.lists.entries).toContain(newMangaEntry);
+          expect(addMangaEntry.emitted('dialogClosed')).toBeTruthy();
+        });
+      });
+
+      describe('when receiving 404 status', () => {
+        it('shows info message with payload data', async () => {
+          const infoMessageMock = jest.spyOn(Message, 'info');
+
+          createEntrySpy.mockResolvedValue(
+            { status: 404, data: 'Manga was not found' },
+          );
+
+          addMangaEntry.vm.addMangaEntry();
+
+          await flushPromises();
+          expect(infoMessageMock).toHaveBeenCalledWith('Manga was not found');
+        });
+      });
+
+      describe('when receiving 406 status', () => {
+        it('shows info message with payload data', async () => {
+          const infoMessageMock = jest.spyOn(Message, 'info');
+
+          createEntrySpy.mockResolvedValue(
+            { status: 406, data: 'Manga already added' },
+          );
+
+          addMangaEntry.vm.addMangaEntry();
+
+          await flushPromises();
+          expect(infoMessageMock).toHaveBeenCalledWith('Manga already added');
+        });
+      });
+
+      it('shows error message on unsuccessful API lookup', async () => {
+        const errorMessageMock = jest.spyOn(Message, 'error');
+
+        createEntrySpy.mockResolvedValue({ status: 500 });
+
+        addMangaEntry.vm.addMangaEntry();
+
+        await flushPromises();
+
+        expect(errorMessageMock).toHaveBeenCalledWith('Something went wrong');
+        expect(addMangaEntry.emitted('dialogClosed')).toBeTruthy();
+      });
+    });
+
+    describe('and there are client-side errors', () => {
+      it.todo('shows validation errors');
+    });
   });
 
   describe(':props', () => {
@@ -46,124 +270,6 @@ describe('AddMangaEntry.vue', () => {
 
         expect(addMangaEntry.vm.selectedStatus).toBe(1);
       });
-    });
-  });
-
-  describe('and there are client-side errors', () => {
-    it.todo('shows validation errors');
-  });
-
-  describe('when adding new manga entry', () => {
-    let createEntrySpy;
-
-    beforeEach(() => {
-      addMangaEntry.setData({ mangaURL: 'http://www.example.url/manga/1' });
-
-      createEntrySpy = jest.spyOn(api, 'create');
-    });
-
-    afterEach(() => {
-      expect(createEntrySpy)
-        .toHaveBeenCalledWith('http://www.example.url/manga/1', 1);
-    });
-
-    describe('when no manga sources are tracked', () => {
-      it('adds new Manga entry', async () => {
-        const mangaEntry = factories.entry.build();
-
-        createEntrySpy.mockResolvedValue({
-          status: 200, data: { data: mangaEntry },
-        });
-
-        addMangaEntry.vm.addMangaEntry();
-
-        await flushPromises();
-
-        expect(store.state.lists.entries).toContain(mangaEntry);
-        expect(addMangaEntry.emitted('dialogClosed')).toBeTruthy();
-      });
-    });
-
-    describe('when other manga source is tracked', () => {
-      it('replaces currently tracked manga entry with the new one', async () => {
-        const oldEntry = factories.entry.build();
-        store.state.lists.entries = [oldEntry];
-
-        const newMangaEntry = factories.entry.build({
-          id: 2,
-          manga_source_id: 2,
-          manga_series_id: oldEntry.manga_series_id,
-          attributes: {
-            tracked_entries: [
-              {
-                id: oldEntry.id,
-                manga_source_id: oldEntry.manga_source_id,
-                manga_series_id: oldEntry.manga_series_id,
-              },
-              {
-                id: 2,
-                manga_source_id: 2,
-                manga_series_id: oldEntry.manga_series_id,
-              },
-            ],
-          },
-        });
-
-        createEntrySpy.mockResolvedValue({
-          status: 200, data: { data: newMangaEntry },
-        });
-
-        addMangaEntry.vm.addMangaEntry();
-
-        await flushPromises();
-
-        expect(store.state.lists.entries).not.toContain(oldEntry);
-        expect(store.state.lists.entries).toContain(newMangaEntry);
-        expect(addMangaEntry.emitted('dialogClosed')).toBeTruthy();
-      });
-    });
-
-    describe('when receiving 404 status', () => {
-      it('shows info message with payload data', async () => {
-        const infoMessageMock = jest.spyOn(Message, 'info');
-
-        createEntrySpy.mockResolvedValue(
-          { status: 404, data: 'Manga was not found' },
-        );
-
-        addMangaEntry.vm.addMangaEntry();
-
-        await flushPromises();
-        expect(infoMessageMock).toHaveBeenCalledWith('Manga was not found');
-      });
-    });
-
-    describe('when receiving 406 status', () => {
-      it('shows info message with payload data', async () => {
-        const infoMessageMock = jest.spyOn(Message, 'info');
-
-        createEntrySpy.mockResolvedValue(
-          { status: 406, data: 'Manga already added' },
-        );
-
-        addMangaEntry.vm.addMangaEntry();
-
-        await flushPromises();
-        expect(infoMessageMock).toHaveBeenCalledWith('Manga already added');
-      });
-    });
-
-    it('shows error message on unsuccessful API lookup', async () => {
-      const errorMessageMock = jest.spyOn(Message, 'error');
-
-      createEntrySpy.mockResolvedValue({ status: 500 });
-
-      addMangaEntry.vm.addMangaEntry();
-
-      await flushPromises();
-
-      expect(errorMessageMock).toHaveBeenCalledWith('Something went wrong');
-      expect(addMangaEntry.emitted('dialogClosed')).toBeTruthy();
     });
   });
 });

--- a/tests/components/manga_entries/AddMangaEntryBySearch.spec.js
+++ b/tests/components/manga_entries/AddMangaEntryBySearch.spec.js
@@ -1,0 +1,164 @@
+import Vuex from 'vuex';
+import { Message } from 'element-ui';
+import flushPromises from 'flush-promises';
+
+import AddMangaEntryBySearch from '@/components/manga_entries/AddMangaEntryBySearch.vue';
+import BaseFormAutocomplete from '@/components/base_components/BaseFormAutocomplete.vue';
+
+import lists from '@/store/modules/lists';
+import * as resource from '@/services/endpoints/v1/manga_series';
+
+const localVue = createLocalVue();
+
+localVue.use(Vuex);
+
+describe('AddMangaEntryBySearch.vue', () => {
+  let store;
+  let bySearch;
+
+  beforeEach(() => {
+    store = new Vuex.Store({
+      modules: {
+        lists: {
+          namespaced: true,
+          state: lists.state,
+        },
+      },
+    });
+
+    bySearch = shallowMount(
+      AddMangaEntryBySearch, {
+        store,
+        localVue,
+        propsData: {
+          searchQuery: '',
+          validator: { mangaSourceID: { required: false, $dirty: false } },
+        },
+      },
+    );
+  });
+
+  describe('when there are client-side errors', () => {
+    it('shows validation errors', () => {
+      bySearch = shallowMount(
+        AddMangaEntryBySearch, {
+          store,
+          localVue,
+          propsData: {
+            searchQuery: '',
+            validator: { mangaSourceID: { required: false, $dirty: true } },
+          },
+          computed: {
+            availableSources: () => [jest.fn()],
+          },
+        },
+      );
+
+      expect(bySearch.find('span').exists()).toBeTruthy();
+      expect(bySearch.find('span').text()).toContain('required');
+    });
+  });
+
+  describe('when searchQuery changes', () => {
+    describe("and it's blank", () => {
+      it('items get reset', async () => {
+        const mangaSeries = factories.series.build();
+        bySearch = shallowMount(
+          AddMangaEntryBySearch, {
+            store,
+            localVue,
+            data() {
+              return { items: [mangaSeries] };
+            },
+            propsData: {
+              searchQuery: 'query',
+              validator: { mangaSourceID: { required: false, $dirty: false } },
+            },
+          },
+        );
+
+        await bySearch.setProps({ searchQuery: '' });
+
+        expect(bySearch.vm.items).toEqual([]);
+      });
+    });
+
+    describe("and it's not blank", () => {
+      let indexMangaSeriesMock;
+
+      beforeEach(() => {
+        indexMangaSeriesMock = jest.spyOn(resource, 'index');
+      });
+
+      it('makes an async request to retrieve series titles', async () => {
+        const mangaSeries = factories.series.buildList(1);
+
+        indexMangaSeriesMock
+          .mockResolvedValue({ status: 200, data: { data: mangaSeries } });
+
+        bySearch.setProps({ searchQuery: 'query' });
+        await flushPromises();
+
+        expect(indexMangaSeriesMock).toHaveBeenCalledWith('query');
+        expect(bySearch.vm.items).toEqual(mangaSeries);
+      });
+
+      describe('and request failed', () => {
+        it('shows an error message', async () => {
+          const errorMessageMock = jest.spyOn(Message, 'error');
+
+          indexMangaSeriesMock.mockResolvedValue({ status: 500 });
+
+          bySearch.setProps({ searchQuery: 'query' });
+          await flushPromises();
+
+          expect(errorMessageMock).toHaveBeenCalledWith(
+            "Couldn't fetch series. Try refreshing the page before trying again",
+          );
+        });
+      });
+    });
+  });
+
+  describe('when availableSources gets set', () => {
+    it('emits mangaSourceSelected for the first available source', async () => {
+      const mangaSeries = factories.series.build();
+      bySearch = shallowMount(
+        AddMangaEntryBySearch, {
+          store,
+          localVue,
+          data() {
+            return { items: [mangaSeries] };
+          },
+          propsData: {
+            searchQuery: 'query',
+            validator: { mangaSourceID: { required: false, $dirty: false } },
+          },
+        },
+      );
+
+      await bySearch.setProps({ selectedSeriesTitle: mangaSeries.title });
+
+      expect(bySearch.emitted('mangaSourceSelected')[0])
+        .toEqual([mangaSeries.mangaSources[0].id]);
+    });
+  });
+
+  describe('when autocomplete component emits selected', () => {
+    it('emits seriesSelected', async () => {
+      await bySearch
+        .findComponent(BaseFormAutocomplete).vm.$emit('selected', 'Title');
+
+      expect(bySearch.emitted('seriesSelected')[0]).toEqual(['Title']);
+    });
+  });
+
+  describe('when autocomplete component emits input', () => {
+    it('emits input', async () => {
+      await bySearch
+        .findComponent(BaseFormAutocomplete).vm.$emit('input', 'Title');
+
+      expect(bySearch.emitted('input')[0]).toEqual(['Title']);
+    });
+  });
+});

--- a/tests/factories/index.js
+++ b/tests/factories/index.js
@@ -1,6 +1,12 @@
 import entry from './mangaEntry';
 import userTag from './UserTag';
 import source from './mangaSource';
+import series from './mangaSeries';
 
 // eslint-disable-next-line import/prefer-default-export
-export const factories = { entry, source, userTag };
+export const factories = {
+  entry,
+  source,
+  series,
+  userTag,
+};

--- a/tests/factories/mangaSeries.js
+++ b/tests/factories/mangaSeries.js
@@ -1,0 +1,12 @@
+import { Factory } from 'fishery';
+import mangaSourceFactory from './mangaSource';
+
+export default Factory.define(({ sequence }) => ({
+  id: sequence,
+  title: 'Title',
+  titleEN: 'Title in English',
+  titleENJP: 'Title in Japanese',
+  kitsuID: sequence,
+  malID: sequence,
+  mangaSources: [mangaSourceFactory.build()],
+}));

--- a/tests/factories/mangaSource.js
+++ b/tests/factories/mangaSource.js
@@ -4,4 +4,7 @@ export default Factory.define(({ sequence }) => ({
   id: sequence,
   manga_series_id: 1,
   name: 'MangaDex',
+  seriesURL: 'example.com',
+  lastVolumeAvailable: 1,
+  lastChapterAvailable: 2,
 }));

--- a/tests/services/api.spec.js
+++ b/tests/services/api.spec.js
@@ -30,6 +30,28 @@ describe('API', () => {
       const response = await apiService.create('', 0);
       expect(response).toBeFalsy();
     });
+
+    describe('when sourceID is present', () => {
+      it('uses it to make a request', async () => {
+        const postMangaEntriesCollectionsSpy = jest.spyOn(axios, 'post');
+        const mangaURL = '';
+        const sourceID = 123;
+        const status = 1;
+
+        await apiService.create(mangaURL, status, sourceID);
+
+        expect(postMangaEntriesCollectionsSpy).toHaveBeenCalledWith(
+          '/api/v1/manga_entries/',
+          {
+            manga_entry: {
+              series_url: mangaURL,
+              status,
+              manga_source_id: sourceID,
+            },
+          },
+        );
+      });
+    });
   });
 
   describe('updateMangaEntry()', () => {

--- a/tests/services/endpoints/v1/manga_series.spec.js
+++ b/tests/services/endpoints/v1/manga_series.spec.js
@@ -1,0 +1,39 @@
+import axios from 'axios';
+import * as resource from '@/services/endpoints/v1/manga_series';
+
+describe('/v1/manga_series', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('index()', () => {
+    let indexSpy;
+
+    beforeEach(() => {
+      indexSpy = jest.spyOn(axios, 'get');
+    });
+
+    describe('makes a request to the resource', () => {
+      it('returns response', async () => {
+        axios.get.mockResolvedValue({ status: 200 });
+
+        const params = { search_term: '' };
+        const successful = await resource.index(params.search_term);
+
+        expect(successful.status).toBe(200);
+        expect(indexSpy)
+          .toHaveBeenCalledWith('/api/v1/manga_series', { params });
+      });
+    });
+
+    describe('makes a failed request to the resource', () => {
+      it('returns response with error status', async () => {
+        axios.get.mockRejectedValue({ response: { status: 500 } });
+
+        const successful = await resource.index(null);
+
+        expect(successful.status).toBe(500);
+      });
+    });
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -8597,6 +8597,16 @@ osenv@^0.1.4:
     os-homedir "^1.0.0"
     os-tmpdir "^1.0.0"
 
+overlayscrollbars-vue@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/overlayscrollbars-vue/-/overlayscrollbars-vue-0.2.2.tgz#4a3d4eaf09dbbaae8c52ff0e9219909075eb920e"
+  integrity sha512-JpDkM+fkNp7YbZxZNf9cbSWCa1tylaSUkmdhux+qtVFekH4zpZpM8+GRtOgs7YDDWyVNPkUBQ8FnMRMoBNfoJw==
+
+overlayscrollbars@^1.13.0:
+  version "1.13.0"
+  resolved "https://registry.yarnpkg.com/overlayscrollbars/-/overlayscrollbars-1.13.0.tgz#1edb436328133b94877b558f77966d5497ca36a7"
+  integrity sha512-p8oHrMeRAKxXDMPI/EBNITj/zTVHKNnAnM59Im+xnoZUlV07FyTg46wom2286jJlXGGfcPFG/ba5NUiCwWNd4w==
+
 p-each-series@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/p-each-series/-/p-each-series-1.0.0.tgz#930f3d12dd1f50e7434457a22cd6f04ac6ad7f71"


### PR DESCRIPTION
This PR adds ability to search through the Kenmei database, when adding series. No need to look for a specific URL. To add a chapter, url is still required, but this should make adding series a lot easier. You can always select which source to track while adding, with soon to be added indicator, for which are online and which are not

[Video Preview](https://imgur.com/a/begKdAu)