### PR TITLE
Add ability to clear local search

### DIFF
--- a/src/components/base_components/BaseFormInput.vue
+++ b/src/components/base_components/BaseFormInput.vue
@@ -23,6 +23,8 @@
         :placeholder="placeholder"
         :type="type"
       )
+      .absolute.inset-y-0.right-0.pr-3.flex.items-center(v-if="$slots.endIcon")
+        slot(name="endIcon")
     p.mt-2.text-xs.text-gray-500(v-if="helperText" v-text="helperText")
 </template>
 

--- a/src/components/icons/IconCross.vue
+++ b/src/components/icons/IconCross.vue
@@ -1,0 +1,8 @@
+<template lang="pug">
+  svg(fill='currentColor' viewbox='0 0 20 20')
+    path(
+      fill-rule='evenodd'
+      d='M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z'
+      clip-rule='evenodd'
+    )
+</template>

--- a/src/views/MangaList.vue
+++ b/src/views/MangaList.vue
@@ -48,6 +48,9 @@
           )
             template(slot='icon')
               icon-search.h-5.w-5.text-gray-400
+            template(v-if="searchTerm.length" slot='endIcon')
+              button.focus_outline-none(@click="searchTerm = ''")
+                icon-cross.h-5.w-5.text-gray-400
       .mx-5.mb-5.max-sm_mx-2.max-sm_flex.max-sm_flex-col
         bulk-actions.mb-3.sm_mb-0(
           v-show="entriesSelected"


### PR DESCRIPTION
This PR adds a couple of things:

1. New icon slot at the end of the base input
2. New cross icon
3. Using the new slot, add a cross icon to clear manga search

![Kapture 2020-10-22 at 20 29 31](https://user-images.githubusercontent.com/4270980/96920657-57cacd00-14a5-11eb-8246-b1e36f50b483.gif)
