### PR TITLE
Validate search term not to be a URL

### DIFF
--- a/src/components/base_components/BaseFormAutocomplete.vue
+++ b/src/components/base_components/BaseFormAutocomplete.vue
@@ -98,9 +98,14 @@
         dropdownOpen: false,
       };
     },
+    computed: {
+      hasErrors() {
+        return this.validator && this.validator.$invalid;
+      },
+    },
     watch: {
       value(newValue) {
-        if (newValue.length) {
+        if (newValue.length && !this.hasErrors) {
           if (!this.selectedValue) { this.dropdownOpen = true; }
         } else {
           this.dropdownOpen = false;
@@ -124,7 +129,7 @@
         this.dropdownOpen = false;
       },
       onFocus() {
-        if (this.value.length) { this.dropdownOpen = true; }
+        if (this.value.length && !this.hasErrors) { this.dropdownOpen = true; }
       },
     },
   };

--- a/src/components/manga_entries/AddMangaEntry.vue
+++ b/src/components/manga_entries/AddMangaEntry.vue
@@ -52,7 +52,7 @@
 </template>
 
 <script>
-  import { required, url } from 'vuelidate/lib/validators';
+  import { required, url, not } from 'vuelidate/lib/validators';
   import { mapState, mapMutations, mapGetters } from 'vuex';
   import { Message, Select, Option } from 'element-ui';
   import debounce from 'lodash/debounce';
@@ -95,6 +95,7 @@
         return {
           searchQuery: {
             required,
+            isNotURL: not(url),
           },
           selectedSeriesTitle: {
             required,

--- a/src/components/manga_entries/AddMangaEntryBySearch.vue
+++ b/src/components/manga_entries/AddMangaEntryBySearch.vue
@@ -36,6 +36,7 @@
 </template>
 
 <script>
+  import debounce from 'lodash/debounce';
   import he from 'he';
   import { Message, Select, Option } from 'element-ui';
   import { mapState } from 'vuex';
@@ -102,8 +103,9 @@
     },
     watch: {
       async searchQuery(title) {
-        if (!title.length) {
-          this.items = [];
+        this.validator.$touch();
+        if (this.validator.searchQuery.$error) {
+          this.resetItems();
           return;
         }
 
@@ -129,6 +131,9 @@
       },
     },
     methods: {
+      resetItems: debounce(function (_e) { // eslint-disable-line func-names
+        this.items = [];
+      }, 200),
     },
   };
 </script>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -6,6 +6,7 @@
     "minLength8": "must have at least 8 letters",
     "maxLength24": "must have at most 24 letters",
     "sameAs": "must be identical",
+    "isNotURL": "can't be a url",
     "mustBeMangaDex": "must be a MDList url"
   }
 }


### PR DESCRIPTION
Many users, by habit, paste the URL, as soon as the do Add Manga. This generates a new query, without them having the chance to switch to another mode. 

To avoid generating extra queries, this PR adds validation for the input not to be a URL. I also make it so the dropdown doesn't open if there are validation errors. Finally, this addresses the issue of the dropdown resetting items too quickly, by debouncing the reset, allowing the dropdown to close gracefully.

![validation-url](https://user-images.githubusercontent.com/4270980/97082259-4e09ac80-1600-11eb-80bb-44298c1491ba.gif)
