### PR TITLE
Fix debounce on BaseFormAutocomplete

### DIFF
--- a/tests/__mocks__/lodash/debounce.js
+++ b/tests/__mocks__/lodash/debounce.js
@@ -1,0 +1,1 @@
+export default (fn) => fn;

--- a/tests/components/base_components/BaseFormAutocomplete.spec.js
+++ b/tests/components/base_components/BaseFormAutocomplete.spec.js
@@ -1,9 +1,6 @@
 import BaseFormAutocomplete from '@/components/base_components/BaseFormAutocomplete.vue';
 
-jest.mock('lodash/debounce', () => jest.fn((fn) => fn));
-
-// TODO: I need to figure out why I can't watch the debounced query
-describe.skip('BaseFormAutocomplete.vue', () => {
+describe('BaseFormAutocomplete.vue', () => {
   let baseFormAutocomplete;
 
   beforeEach(() => {

--- a/tests/components/manga_entries/AddMangaEntry.spec.js
+++ b/tests/components/manga_entries/AddMangaEntry.spec.js
@@ -11,8 +11,6 @@ const localVue = createLocalVue();
 
 localVue.use(Vuex);
 
-jest.mock('lodash/debounce', () => jest.fn((fn) => fn));
-
 describe('AddMangaEntry.vue', () => {
   let store;
   let addMangaEntry;

--- a/tests/components/manga_entries/AddMangaEntryBySearch.spec.js
+++ b/tests/components/manga_entries/AddMangaEntryBySearch.spec.js
@@ -11,7 +11,6 @@ import * as resource from '@/services/endpoints/v1/manga_series';
 const localVue = createLocalVue();
 
 localVue.use(Vuex);
-jest.mock('lodash/debounce', () => jest.fn((fn) => fn));
 
 describe('AddMangaEntryBySearch.vue', () => {
   let store;

--- a/tests/components/settings/SettingsMangaListTags.spec.js
+++ b/tests/components/settings/SettingsMangaListTags.spec.js
@@ -10,7 +10,6 @@ const localVue = createLocalVue();
 
 // To avoid missing directive Vue warnings
 localVue.directive('loading', true);
-jest.mock('lodash/debounce', () => jest.fn((fn) => fn));
 
 describe('SettingsMangaListTags.vue', () => {
   afterEach(() => { jest.restoreAllMocks(); });


### PR DESCRIPTION
Fixing that skipped debounce mock that was almost there but jest _is_ temperamental…
<img width="728" alt="image" src="https://user-images.githubusercontent.com/385232/97762736-63e80780-1b01-11eb-8012-6025ed6ac901.png">
