### PR TITLE
Add extra guard to avoid error on sign out

### DIFF
--- a/src/components/settings/SettingsAccountProfileSection.vue
+++ b/src/components/settings/SettingsAccountProfileSection.vue
@@ -49,6 +49,7 @@
         'currentUser',
       ]),
       unconfirmedEmail() {
+        if (!this.currentUser) return;
         if (!this.currentUser.unconfirmedEmail) return;
 
         // eslint-disable-next-line consistent-return


### PR DESCRIPTION
An error would be raised, if a user tried to log out from the settings page, as the computed property would try to evaluate currentUser unconfirmedEmail, even tho the object is now null