### PR TITLE
Fetch fresh data after deletion from manga list

### DIFF
--- a/src/store/modules/lists.js
+++ b/src/store/modules/lists.js
@@ -75,11 +75,6 @@ const mutations = {
   replaceEntry(state, { currentEntry, newEntry }) {
     state.entries.splice(getEntryIndex(state, currentEntry.id), 1, newEntry);
   },
-  removeEntries(state, entryIDs) {
-    state.entries = state.entries.filter(
-      (mangaEntry, _index, _arr) => !entryIDs.includes(mangaEntry.id),
-    );
-  },
   setTagsLoading(state, data) {
     state.tagsLoading = data;
   },

--- a/src/views/MangaList.vue
+++ b/src/views/MangaList.vue
@@ -245,7 +245,7 @@
 
         if (successful) {
           Message.info(`${this.trackedEntriesIDs.length} entries deleted`);
-          this.removeEntries(this.trackedEntriesIDs);
+          this.changePage(this.entriesPagy.page);
         } else {
           Message.error(
             'Deletion failed. Try reloading the page before trying again',

--- a/src/views/MangaList.vue
+++ b/src/views/MangaList.vue
@@ -229,7 +229,6 @@
       ]),
       ...mapMutations('lists', [
         'setSelectedEntries',
-        'removeEntries',
         'setTagsLoading',
         'updateEntry',
       ]),

--- a/tests/store/modules/lists.spec.js
+++ b/tests/store/modules/lists.spec.js
@@ -144,23 +144,6 @@ describe('lists', () => {
       });
     });
 
-    describe('removeEntries', () => {
-      it('removes a manga entry', () => {
-        const entryToStay = factories.entry.build({ id: '1' });
-        const state = {
-          entries: [
-            entryToStay,
-            factories.entry.build({ id: '2' }),
-            factories.entry.build({ id: '3' }),
-          ],
-        };
-
-        lists.mutations.removeEntries(state, ['2', '3']);
-
-        expect(state.entries).toEqual([entryToStay]);
-      });
-    });
-
     describe('setTagsLoading', () => {
       it('sets tagsLoading state', () => {
         const state = { tagsLoading: false };

--- a/tests/views/MangaList.spec.js
+++ b/tests/views/MangaList.spec.js
@@ -54,6 +54,7 @@ describe('MangaList.vue', () => {
             tags: [tag1, tag2],
             entries: [entry1, entry2, entry3],
             selectedEntries: [],
+            entriesPagy: { page: 1 },
             statuses: lists.state.statuses,
           },
           actions: lists.actions,
@@ -305,9 +306,11 @@ describe('MangaList.vue', () => {
 
     describe('when entry does not have multiple sources tracked', () => {
       let bulkDeleteMangaEntriesMock;
+      let indexMangaEntriesSpy;
 
       beforeEach(() => {
         bulkDeleteMangaEntriesMock = jest.spyOn(api, 'bulkDeleteMangaEntries');
+        indexMangaEntriesSpy = jest.spyOn(mangaEntriesResource, 'index');
       });
 
       afterEach(() => {
@@ -327,14 +330,18 @@ describe('MangaList.vue', () => {
           expect(infoMessageMock).toHaveBeenCalledWith('1 entries deleted');
         });
 
-        it('removes deleted entries', async () => {
-          expect(mangaList.vm.entries).toContain(entry1);
-
+        it('fetches the new pagy object with updated entries', async () => {
           mangaList.vm.deleteEntries();
 
           await flushPromises();
 
-          expect(mangaList.vm.entries).not.toContain(entry1);
+          expect(indexMangaEntriesSpy).toHaveBeenCalledWith(
+            1,
+            mangaList.vm.$data.selectedStatus,
+            mangaList.vm.$data.selectedTagIDs,
+            mangaList.vm.$data.searchTerm,
+            mangaList.vm.$data.selectedSort,
+          );
         });
       });
 


### PR DESCRIPTION
Previously, I would delete entries directly from the store, which meant our pagy would be wrong and if I deleted all the page entries, it would look like there are no entries left.

Instead, we want to just make a request for the fresh data, to make sure the list is up to date after deletion has happened