### PR TITLE
Disable user scaling

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8"/>
     <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
-    <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no"/>
     <meta name="application-name" content="Kenmei | Cross-site manga tracker"/>
     <meta name="Description" content="Cross-site manga tracker, that lets you read and track manga across websites.">
     <!-- Full-screen mode on home screen apps -->


### PR DESCRIPTION
This will disallow users to accidentally zoom on their mobile devices. If they do, it breaks the immersion of making users think that the web app is a mobile app