### PR TITLE
Disable camelcase eslint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -20,6 +20,7 @@ module.exports = {
     'vue',
   ],
   rules: {
+    camelcase: 'off',
     'no-nested-ternary': 'off',
     'no-unused-vars': ['error', { argsIgnorePattern: '^_', ignoreRestSiblings: true }],
     'comma-dangle': ['error', 'always-multiline'],


### PR DESCRIPTION
As I currently return attributes in pascal case from the API, until I start transforming them into CamelCase, I should disable this rule, as otherwise I get errors everwhere