### PR TITLE
Fix race condition when trying to refresh token

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@tailwindcss/ui": "~0.6.2",
     "add": "^2.0.6",
     "axios": "^0.21.0",
+    "axios-auth-refresh": "^3.0.0",
     "body-scroll-lock": "=3.0.2",
     "core-js": "^3.3.2",
     "dayjs": "^1.9.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2871,6 +2871,11 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.10.0.tgz#a17b3a8ea811060e74d47d306122400ad4497ae2"
   integrity sha512-3YDiu347mtVtjpyV3u5kVqQLP242c06zwDOgpeRnybmXlYYsLbtTrUBUm8i8srONt+FWobl5aibnU1030PeeuA==
 
+axios-auth-refresh@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/axios-auth-refresh/-/axios-auth-refresh-3.0.0.tgz#dd8c8a8458250c554c9b00c6b2cf571397c8eec6"
+  integrity sha512-0XJnJY711f7opdT+b/au/xw1g4MYrjntXB8Oy5l48plbzOWLjUtJ+m8CtiNLgN3MAvGFJ/Q1NtQ7WKf2euKu6g==
+
 axios@^0.21.0:
   version "0.21.0"
   resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.0.tgz#26df088803a2350dff2c27f96fef99fe49442aca"


### PR DESCRIPTION
Previously, I had a simple interceptor, for when a request fails with a 401 status, it would try to refresh the token. But, if it's not resolved fast enough and a user makes a new request, which gets a 401 again, we will end up trying to refresh the token _again_, which at this point will fail, resulting in the user getting kicked out of the session. Here is a [good overview of the problem ](https://tech.just-eat.com/2019/12/04/lessons-learned-from-handling-jwt-on-mobile/)

To address this issue, I am using a library that specifically creates the interceptor for me and queues requests, meaning only one refresh token request will be present at the time, and then a promise chain will update all the queued requests with the new token.