### PR TITLE
Fetch latest pagy from the API when entry is added

### DIFF
--- a/src/components/manga_entries/AddMangaEntry.vue
+++ b/src/components/manga_entries/AddMangaEntry.vue
@@ -177,7 +177,7 @@
             this.addEntry(entryData);
           }
 
-          this.$emit('dialogClosed');
+          this.$emit('entry-added');
 
           Message.info('New Entry added');
         } else if (status === 404 || status === 406) {

--- a/src/services/endpoints/v2/manga_entries.js
+++ b/src/services/endpoints/v2/manga_entries.js
@@ -3,7 +3,6 @@ import qs from 'qs';
 
 const baseURL = '/api/v2/manga_entries';
 
-/* eslint-disable import/prefer-default-export, object-curly-newline */
 export const index = (page, status, tagIDs, searchTerm, sort) => secure
   .get(baseURL, {
     params: {
@@ -15,4 +14,14 @@ export const index = (page, status, tagIDs, searchTerm, sort) => secure
   })
   .then((response) => response)
   .catch((request) => request.response);
-/* eslint-enable import/prefer-default-export */
+export const pagyInfo = (page, status, tagIDs, searchTerm, sort) => secure
+  .get(`${baseURL}/pagy_info`, {
+    params: {
+      page, status, user_tag_ids: tagIDs, search_term: searchTerm, sort,
+    },
+    paramsSerializer: (params) => qs.stringify(params, {
+      arrayFormat: 'brackets',
+    }),
+  })
+  .then((response) => response)
+  .catch((request) => request.response);

--- a/src/store/modules/lists.js
+++ b/src/store/modules/lists.js
@@ -55,6 +55,17 @@ const actions = {
 
     commit('setEntriesLoading', false);
   },
+  async getEntriesPagy({ commit }, { page, status, tagIDs, searchTerm, sort }) {
+    const response = await mangaEntries.pagyInfo(
+      page, status, tagIDs, searchTerm, sort,
+    );
+
+    if (response.status === 200) {
+      commit('setEntriesPagy', response.data);
+    } else {
+      Message.error(response.data.error);
+    }
+  },
 };
 
 const mutations = {

--- a/src/views/MangaList.vue
+++ b/src/views/MangaList.vue
@@ -32,6 +32,7 @@
         :visible="dialogVisible"
         :currentStatus="selectedStatus"
         @dialogClosed='dialogVisible = false'
+        @entry-added='updatePagy'
       )
       edit-manga-entries(
         ref='editMangaEntryModal'
@@ -161,6 +162,7 @@
       ...mapActions('lists', [
         'getTags',
         'getEntries',
+        'getEntriesPagy',
       ]),
       ...mapMutations('lists', [
         'setSelectedEntries',
@@ -223,6 +225,15 @@
         await this.getEntries({ page: 1, ...this.filters, sort });
 
         this.setTagsLoading(false);
+      },
+      async updatePagy() {
+        await this.getEntriesPagy({
+          page: this.entriesPagy.page,
+          ...this.filters,
+          sort: this.selectedSort,
+        });
+
+        this.dialogVisible = false;
       },
       resetEntries(dialogName) {
         this[dialogName] = false;

--- a/tests/components/manga_entries/AddMangaEntry.spec.js
+++ b/tests/components/manga_entries/AddMangaEntry.spec.js
@@ -132,7 +132,7 @@ describe('AddMangaEntry.vue', () => {
           await flushPromises();
 
           expect(store.state.lists.entries).toContain(mangaEntry);
-          expect(addMangaEntry.emitted('dialogClosed')).toBeTruthy();
+          expect(addMangaEntry.emitted('entry-added')).toBeTruthy();
         });
       });
 
@@ -171,7 +171,7 @@ describe('AddMangaEntry.vue', () => {
 
           expect(store.state.lists.entries).not.toContain(oldEntry);
           expect(store.state.lists.entries).toContain(newMangaEntry);
-          expect(addMangaEntry.emitted('dialogClosed')).toBeTruthy();
+          expect(addMangaEntry.emitted('entry-added')).toBeTruthy();
         });
       });
 

--- a/tests/services/endpoints/v2/manga_entries.spec.js
+++ b/tests/services/endpoints/v2/manga_entries.spec.js
@@ -53,4 +53,52 @@ describe('/v2/manga_entries', () => {
       });
     });
   });
+
+  describe('pagyInfo()', () => {
+    let pagyInfoSpy;
+
+    beforeEach(() => {
+      pagyInfoSpy = jest.spyOn(axios, 'get');
+    });
+
+    describe('makes a request to the resource', () => {
+      it('returns response', async () => {
+        axios.get.mockResolvedValue({ status: 200 });
+
+        const params = {
+          page: 1,
+          status: 'reading',
+          tagIDs: [],
+          searchTerm: '',
+          sort: { Title: 'asc' },
+        };
+
+        const successful = await resource.pagyInfo(...Object.values(params));
+
+        expect(successful.status).toBe(200);
+        expect(pagyInfoSpy).toHaveBeenCalledWith(
+          '/api/v2/manga_entries/pagy_info',
+          expect.objectContaining({
+            params: {
+              page: params.page,
+              status: params.status,
+              user_tag_ids: params.tagIDs,
+              search_term: params.searchTerm,
+              sort: params.sort,
+            },
+          }),
+        );
+      });
+    });
+
+    describe('makes a failed request to the resource', () => {
+      it('returns response with error status', async () => {
+        axios.get.mockRejectedValue({ response: { status: 500 } });
+
+        const successful = await resource.pagyInfo({});
+
+        expect(successful.status).toBe(500);
+      });
+    });
+  });
 });

--- a/tests/store/modules/lists.spec.js
+++ b/tests/store/modules/lists.spec.js
@@ -318,5 +318,64 @@ describe('lists', () => {
         expect(commit).not.toHaveBeenCalledWith('setEntriesPagy');
       });
     });
+
+    describe('getEntriesPagy', () => {
+      let params;
+
+      beforeEach(() => {
+        params = {
+          page: 1,
+          status: 'reading',
+          tagIDs: [],
+          searchTerm: '',
+          sort: { Title: 'asc' },
+        };
+      });
+
+      it('retrieves pagy object from the API', async () => {
+        const mangaEntriesSpy = jest.spyOn(mangaEntries, 'pagyInfo');
+        const data = {
+          count: 1,
+          from: 1,
+          items: 1,
+          last: 1,
+          next: null,
+          offset: 0,
+          outset: 0,
+          page: 1,
+          pages: 1,
+          prev: null,
+          to: 1,
+        };
+
+        mangaEntriesSpy.mockResolvedValue({
+          status: 200, data,
+        });
+
+        lists.actions.getEntriesPagy({ commit }, params);
+
+        await flushPromises();
+
+        expect(mangaEntriesSpy).toHaveBeenCalledWith(...Object.values(params));
+        expect(commit).toHaveBeenCalledWith('setEntriesPagy', data);
+      });
+
+      it('shows error message if request has failed', async () => {
+        const mangaEntriesSpy = jest.spyOn(mangaEntries, 'pagyInfo');
+        const errorMessageSpy = jest.spyOn(Message, 'error');
+
+        const data = { error: 'Pagination failed' };
+
+        mangaEntriesSpy.mockResolvedValue({ status: 500, data });
+
+        lists.actions.getEntriesPagy({ commit }, params);
+
+        await flushPromises();
+
+        expect(mangaEntriesSpy).toHaveBeenCalledWith(...Object.values(params));
+        expect(errorMessageSpy).toHaveBeenLastCalledWith(data.error);
+        expect(commit).not.toHaveBeenCalledWith('setEntriesPagy');
+      });
+    });
   });
 });

--- a/tests/views/MangaList.spec.js
+++ b/tests/views/MangaList.spec.js
@@ -90,10 +90,23 @@ describe('MangaList.vue', () => {
       expect(modal.element).toBeVisible();
     });
 
-    describe('@events', () => {
-      it('@dialogClosed - closes add manga dialog', () => {
+    describe('and dialog got closed', () => {
+      it('closes add manga dialog', () => {
         mangaList.findComponent(AddMangaEntry).vm.$emit('dialogClosed');
 
+        expect(mangaList.vm.$data.dialogVisible).toBe(false);
+      });
+    });
+
+    describe('and entry was added', () => {
+      it('fetches new pagy object and closes the dialog', async () => {
+        const getEntriesPagySpy = jest.spyOn(mangaList.vm, 'getEntriesPagy')
+
+        mangaList.findComponent(AddMangaEntry).vm.$emit('entry-added');
+
+        await flushPromises();
+
+        expect(getEntriesPagySpy).toHaveBeenCalled();
         expect(mangaList.vm.$data.dialogVisible).toBe(false);
       });
     });


### PR DESCRIPTION
Previously, when adding an entry, my pagy won't get updated. This was especially bad when you are adding entries for the first time, as you won't see the select all button or pagination information. On a smaller scale, it meant that pagination won't reflect the correct count when adding entries

This fixes it, by using a new endpoint on the API, that just provides the pagination data based on the provided scope. So after an entry is added, I now do a quick query to get the latest pagy and then update mine, while keeping the same logic of adding/replacing an entry on the client side. 

By only fetching the pagy object, without entries serialisation, I am able to keep this function really fast and I plan to utilise this on the entry deletion, to improve the speed of deleting entries

## Issue with adding entry to the newly created list
![Screenshot 2020-12-30 at 09 33 36](https://user-images.githubusercontent.com/4270980/103440063-8221cf00-4c3a-11eb-8a5f-97082c862338.png)
![Screenshot 2020-12-30 at 09 32 17](https://user-images.githubusercontent.com/4270980/103440061-81893880-4c3a-11eb-9616-60af96b43ea7.png)
