### PR TITLE
Per row loading based on requests performed + perf improvement

### DIFF
--- a/src/components/manga_list/TheMangaListRow.vue
+++ b/src/components/manga_list/TheMangaListRow.vue
@@ -12,7 +12,7 @@
         :class='checkBoxClasses'
         @input="selectEntry"
       )
-      row-skeleton(v-if="entriesLoading || entryLoading")
+      row-skeleton(v-if="entriesLoading || itemLoading")
       template(v-else)
         span.relative(:class="pingClasses")
           span(v-if="!item.attributes.unread")
@@ -55,15 +55,11 @@
         required: true,
       },
     },
-    data() {
-      return {
-        entryLoading: false,
-      };
-    },
     computed: {
       ...mapState('lists', [
         'selectedEntries',
         'entriesLoading',
+        'entriesUpdating',
         'checkboxToggled',
       ]),
       ...mapGetters('lists', [
@@ -89,6 +85,9 @@
       },
       itemSelected() {
         return this.selectedEntries.includes(this.item) && this.checkboxToggled;
+      },
+      itemLoading() {
+        return this.selectedEntries.includes(this.item) && this.entriesUpdating;
       },
       lastReadTranslation() {
         const { last_chapter_available, unread } = this.item.attributes;
@@ -145,6 +144,7 @@
         'updateEntry',
         'addSelectedEntry',
         'setSelectedEntries',
+        'setEntriesUpdating',
       ]),
       editModeSelection(e) {
         if (!this.selectionModeActive) return;
@@ -166,7 +166,9 @@
         }
       },
       async setLastRead() {
-        this.entryLoading = true;
+        this.addSelectedEntry({ entry: this.item, isCheckbox: false });
+        this.setEntriesUpdating(true);
+
         const { id } = this.item;
 
         const response = await updateMangaEntry(id, this.updateAttributes);
@@ -177,7 +179,8 @@
           Message.error("Couldn't update. Try refreshing the page");
         }
 
-        this.entryLoading = false;
+        this.setEntriesUpdating(false);
+        this.setSelectedEntries({ entries: [], isCheckbox: false });
       },
       handleClick(action) {
         if (action === 'Edit') {

--- a/src/store/modules/lists.js
+++ b/src/store/modules/lists.js
@@ -21,6 +21,7 @@ const state = {
   ],
   tagsLoading: false,
   entriesLoading: true,
+  entriesUpdating: false,
   checkboxToggled: false,
 };
 
@@ -96,11 +97,19 @@ const mutations = {
   replaceEntry(state, { currentEntry, newEntry }) {
     state.entries.splice(getEntryIndex(state, currentEntry.id), 1, newEntry);
   },
+  removeEntries(state, entryIDs) {
+    state.entries = state.entries.filter(
+      (mangaEntry, _index, _arr) => !entryIDs.includes(mangaEntry.id),
+    );
+  },
   setTagsLoading(state, data) {
     state.tagsLoading = data;
   },
   setEntriesLoading(state, data) {
     state.entriesLoading = data;
+  },
+  setEntriesUpdating(state, data) {
+    state.entriesUpdating = data;
   },
 };
 


### PR DESCRIPTION
This PR does a couple of things:

1. Tracks if entries are being updated and then shows skeleton loaders for MangaListRow that is selected, if entries are being updated
2. Updates deletion to keep pagination synchronous, without having to fetch all the new entries
3. Fixes the issue of deleting the last entry of the page - automatically loads the previous page, if such thing occurs, instead of getting an overflow error, by trying to load the current (non-existent) page