### PR TITLE
Show skeleton loading when deleting or updating single or multiple entries

### DIFF
--- a/src/store/modules/lists.js
+++ b/src/store/modules/lists.js
@@ -21,6 +21,7 @@ const state = {
   ],
   tagsLoading: false,
   entriesLoading: true,
+  entriesUpdating: false,
   checkboxToggled: false,
 };
 
@@ -101,6 +102,9 @@ const mutations = {
   },
   setEntriesLoading(state, data) {
     state.entriesLoading = data;
+  },
+  setEntriesUpdating(state, data) {
+    state.entriesUpdating = data;
   },
 };
 

--- a/src/views/MangaList.vue
+++ b/src/views/MangaList.vue
@@ -41,7 +41,7 @@
       )
       delete-manga-entries(
         :visible='deleteDialogVisible'
-        @dialogClosed='deleteDialogVisible = false'
+        @dialogClosed="resetEntries('deleteDialogVisible')"
         @confirmDeletion='deleteDialogVisible = false; removeSeries()'
       )
       report-manga-entries(

--- a/src/views/MangaList.vue
+++ b/src/views/MangaList.vue
@@ -167,6 +167,7 @@
       ...mapMutations('lists', [
         'setSelectedEntries',
         'setTagsLoading',
+        'setEntriesUpdating',
         'updateEntry',
       ]),
       deleteEntries() {
@@ -177,6 +178,8 @@
         }
       },
       async removeSeries() {
+        this.setEntriesUpdating(true);
+
         const successful = await bulkDeleteMangaEntries(this.trackedEntriesIDs);
 
         if (successful) {
@@ -187,8 +190,12 @@
             'Deletion failed. Try reloading the page before trying again',
           );
         }
+
+        this.setEntriesUpdating(false);
       },
       async updateEntries() {
+        this.setEntriesUpdating(true);
+
         const attributes = this.selectedEntries.map((entry) => ({
           id: entry.id,
           last_volume_read: entry.attributes.last_volume_available,
@@ -206,6 +213,8 @@
         } else {
           Message.error("Couldn't update. Try refreshing the page");
         }
+
+        this.setEntriesUpdating(false);
       },
       async changePage(page) {
         this.setTagsLoading(true);

--- a/tests/store/modules/lists.spec.js
+++ b/tests/store/modules/lists.spec.js
@@ -211,6 +211,16 @@ describe('lists', () => {
         expect(state.entriesLoading).toBeTruthy();
       });
     });
+
+    describe('setEntriesUpdating', () => {
+      it('sets entriesLoading state', () => {
+        const state = { entriesUpdating: false };
+
+        lists.mutations.setEntriesUpdating(state, true);
+
+        expect(state.entriesUpdating).toBeTruthy();
+      });
+    });
   });
 
   describe('actions', () => {


### PR DESCRIPTION
Previously, I was only showing skeleton loader when updating the chapter information, but when deleting on marking in bulk, we won't show any indication. This PR changes it by properly toggling loading for specific rows

I also fix a bug I missed previously, where cancelling deletion confirmation, would not reset SelectedEntries, resulting in a possibility of deleting entries that you didn't intend to


https://user-images.githubusercontent.com/4270980/103464139-5fbaaf00-4d29-11eb-91a9-0792923d7135.mp4

