### PR TITLE
Axios timeout and retry fetching entries

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "overlayscrollbars-vue": "^0.2.2",
     "pug-plain-loader": "^1.0.0",
     "qs": "^6.9.3",
+    "retry-axios": "^2.4.0",
     "vue": "^2.6.12",
     "vue-analytics": "^5.22.1",
     "vue-i18n": "^8.0.0",

--- a/src/services/endpoints/v2/manga_entries.js
+++ b/src/services/endpoints/v2/manga_entries.js
@@ -11,9 +11,21 @@ export const index = (page, status, tagIDs, searchTerm, sort) => secure
     paramsSerializer: (params) => qs.stringify(params, {
       arrayFormat: 'brackets',
     }),
+    timeout: 3000,
   })
   .then((response) => response)
-  .catch((request) => request.response);
+  .catch((request) => {
+    if (request.message.includes('timeout')) {
+      return {
+        status: 408,
+        data: {
+          error: 'Something went wrong, try again later or contact hi@kenmei.co',
+        },
+      };
+    }
+
+    return request.response;
+  });
 export const pagyInfo = (page, status, tagIDs, searchTerm, sort) => secure
   .get(`${baseURL}/pagy_info`, {
     params: {

--- a/src/store/modules/lists.js
+++ b/src/store/modules/lists.js
@@ -40,7 +40,7 @@ const actions = {
 
     return status === 200 ? commit('setTags', data) : Message.error(data.error);
   },
-  async getEntries({ commit }, { page, status, tagIDs, searchTerm, sort }) {
+  async getEntries({ commit, state }, { page, status, tagIDs, searchTerm, sort }) {
     commit('setEntriesLoading', true);
 
     const response = await mangaEntries.index(
@@ -51,6 +51,7 @@ const actions = {
       commit('setEntries', response.data.entries);
       commit('setEntriesPagy', response.data.pagy);
     } else {
+      commit('setEntriesPagy', { ...state.entriesPagy });
       Message.error(response.data.error);
     }
 

--- a/tests/store/modules/lists.spec.js
+++ b/tests/store/modules/lists.spec.js
@@ -6,6 +6,12 @@ import * as userTags from '@/services/endpoints/UserTags';
 import * as mangaEntries from '@/services/endpoints/v2/manga_entries';
 
 describe('lists', () => {
+  let defaultState;
+
+  beforeEach(() => {
+    defaultState = { ...lists.state };
+  });
+
   describe('getters', () => {
     describe('findEntryFromIDs', () => {
       it('returns first found entry based on entry IDs being passed', () => {
@@ -318,7 +324,7 @@ describe('lists', () => {
 
         mangaEntriesSpy.mockResolvedValue({ status: 500, data });
 
-        lists.actions.getEntries({ commit }, params);
+        lists.actions.getEntries({ commit, state: defaultState }, params);
 
         await flushPromises();
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -10079,6 +10079,11 @@ ret@~0.1.10:
   resolved "https://registry.yarnpkg.com/ret/-/ret-0.1.15.tgz#b8a4825d5bdb1fc3f6f53c2bc33f81388681c7bc"
   integrity sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==
 
+retry-axios@^2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/retry-axios/-/retry-axios-2.4.0.tgz#b5da2afed8dd0134c73c86206e1d1881d7c66a67"
+  integrity sha512-rK7UBYgbrNoVothbSmM0tEm9DIiXapmVUrnUYn+d9AuQvF0AY5RkJU2FQvlufe9hlFwrCdDhrJTwiyRtR7wUaA==
+
 retry@^0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/retry/-/retry-0.12.0.tgz#1b42a6266a21f07421d1b0b54b7dc167b01c013b"


### PR DESCRIPTION
This is an experimental retry approach to fetching from the back-end. There could be some weird hiccups, stalling a request for up to 30 seconds when a simple　extra request would be done in milliseconds

So now we try this extra request. If it doesn't work, we'll just show you the page you were still on. This is done　using the re-assignment of pagy object, as we have an internal current page counter, that we need to reset