### PR TITLE
Overwrite last read at in seconds

### DIFF
--- a/src/components/manga_list/TheMangaListRowBody.vue
+++ b/src/components/manga_list/TheMangaListRowBody.vue
@@ -72,7 +72,15 @@
     },
     filters: {
       timeAgo(datetime) {
-        return dayjs().to(dayjs(datetime));
+        const relative = dayjs().to(dayjs(datetime));
+
+        // TODO: I should evalute if I can update configuration directly
+        // https://day.js.org/docs/en/customization/relative-time
+        if (['in a few seconds', 'a few seconds ago'].includes(relative)) {
+          return 'just now';
+        }
+
+        return relative;
       },
     },
     props: {

--- a/tests/components/manga_list/TheMangaListRowBody.spec.js
+++ b/tests/components/manga_list/TheMangaListRowBody.spec.js
@@ -1,7 +1,7 @@
-import TheMangaListRowBody from '@/components/manga_list/TheMangaListRowBody.vue';
-import Chapter from '@/components/manga_list/TheMangaListRowBodyChapter.vue';
-
 import Vuex from 'vuex';
+import dayjs from 'dayjs';
+
+import TheMangaListRowBody from '@/components/manga_list/TheMangaListRowBody.vue';
 
 import lists from '@/store/modules/lists';
 
@@ -66,6 +66,36 @@ describe('TheMangaListRowBody.vue', () => {
 
       it("shows haven't read yet", () => {
         expect(rowBody.text()).toContain("Haven't read yet");
+      });
+    });
+  });
+
+  describe('when last read is known', () => {
+    describe('and it was couple seconds in the future', () => {
+      beforeEach(() => {
+        entry = factories.entry.build({
+          attributes: { last_read_at: dayjs().add(10, 'second') },
+        });
+
+        rowBody.setProps({ item: entry });
+      });
+
+      it('shows just now as last read', () => {
+        expect(rowBody.text()).toContain('Read just now');
+      });
+    });
+
+    describe('and it was in the past few seconds', () => {
+      beforeEach(() => {
+        entry = factories.entry.build({
+          attributes: { last_read_at: dayjs().subtract(10, 'second') },
+        });
+
+        rowBody.setProps({ item: entry });
+      });
+
+      it('shows just now as last read', () => {
+        expect(rowBody.text()).toContain('Read just now');
       });
     });
   });


### PR DESCRIPTION
Instead of showing in a few seconds or a few seconds ago, I will just display Read just now instead. This should address bug with showing in a few seconds, as well as make it more user friendly

There is a way to overwrite this on the whole dayjs config, but I am not sure if I want to affect other dates, so I just left it as TODO till future